### PR TITLE
Work-around fix for #59

### DIFF
--- a/src/main/java/com/leonardobishop/quests/Quests.java
+++ b/src/main/java/com/leonardobishop/quests/Quests.java
@@ -198,7 +198,7 @@ public class Quests extends JavaPlugin {
                     if (qPlayer.isOnlyDataLoaded()) {
                         continue;
                     }
-                    qPlayer.getQuestProgressFile().saveToDisk();
+                    qPlayer.getQuestProgressFile().saveToDisk(false);
                 }
             }
         }.runTaskTimerAsynchronously(this, 12000L, 12000L);
@@ -245,7 +245,7 @@ public class Quests extends JavaPlugin {
             if (qPlayer.isOnlyDataLoaded()) {
                 continue;
             }
-            qPlayer.getQuestProgressFile().saveToDisk();
+            qPlayer.getQuestProgressFile().saveToDisk(true);
         }
     }
 

--- a/src/main/java/com/leonardobishop/quests/commands/CommandQuests.java
+++ b/src/main/java/com/leonardobishop/quests/commands/CommandQuests.java
@@ -159,7 +159,7 @@ public class CommandQuests implements CommandExecutor {
                             }
                             QuestProgressFile questProgressFile = plugin.getPlayerManager().getPlayer(uuid).getQuestProgressFile();
                             questProgressFile.clear();
-                            questProgressFile.saveToDisk();
+                            questProgressFile.saveToDisk(false);
                             sender.sendMessage(Messages.COMMAND_QUEST_ADMIN_FULLRESET.getMessage().replace("{player}", name));
                             return true;
                         }
@@ -231,7 +231,7 @@ public class CommandQuests implements CommandExecutor {
                         }
                         if (args[2].equalsIgnoreCase("reset")) {
                             questProgressFile.generateBlankQuestProgress(quest.getId());
-                            questProgressFile.saveToDisk();
+                            questProgressFile.saveToDisk(false);
                             sender.sendMessage(Messages.COMMAND_QUEST_ADMIN_RESET_SUCCESS.getMessage().replace("{player}", name).replace("{quest}", quest.getId()));
                             success = true;
                         } else if (args[2].equalsIgnoreCase("start")) {
@@ -258,12 +258,12 @@ public class CommandQuests implements CommandExecutor {
                                 sender.sendMessage(Messages.COMMAND_QUEST_ADMIN_START_FAILCATEGORYPERMISSION.getMessage().replace("{player}", name).replace("{quest}", quest.getId()));
                                 return true;
                             }
-                            questProgressFile.saveToDisk();
+                            questProgressFile.saveToDisk(false);
                             sender.sendMessage(Messages.COMMAND_QUEST_ADMIN_START_SUCCESS.getMessage().replace("{player}", name).replace("{quest}", quest.getId()));
                             success = true;
                         } else if (args[2].equalsIgnoreCase("complete")) {
                             questProgressFile.completeQuest(quest);
-                            questProgressFile.saveToDisk();
+                            questProgressFile.saveToDisk(false);
                             sender.sendMessage(Messages.COMMAND_QUEST_ADMIN_COMPLETE_SUCCESS.getMessage().replace("{player}", name).replace("{quest}", quest.getId()));
                             success = true;
                         }

--- a/src/main/java/com/leonardobishop/quests/events/EventPlayerLeave.java
+++ b/src/main/java/com/leonardobishop/quests/events/EventPlayerLeave.java
@@ -22,7 +22,7 @@ public class EventPlayerLeave implements Listener {
         new BukkitRunnable() {
             @Override
             public void run() {
-                 plugin.getPlayerManager().getPlayer(playerUuid).getQuestProgressFile().saveToDisk();
+                 plugin.getPlayerManager().getPlayer(playerUuid).getQuestProgressFile().saveToDisk(false);
                 new BukkitRunnable() {
                     @Override
                     public void run() {

--- a/src/main/java/com/leonardobishop/quests/player/questprogressfile/QuestProgressFile.java
+++ b/src/main/java/com/leonardobishop/quests/player/questprogressfile/QuestProgressFile.java
@@ -276,7 +276,7 @@ public class QuestProgressFile {
         return false;
     }
 
-    public void saveToDisk() {
+    public void saveToDisk(boolean disable) {
         File directory = new File(plugin.getDataFolder() + File.separator + "playerdata");
         if (!directory.exists() && !directory.isDirectory()) {
             directory.mkdirs();
@@ -310,14 +310,19 @@ public class QuestProgressFile {
 
         try {
             data.save(file);
-            new BukkitRunnable() {
-                @Override
-                public void run() {
-                    for (QuestProgress questProgress : questProgress.values()) {
-                        questProgress.resetModified();
-                    }
+            if (disable)
+                for (QuestProgress questProgress : questProgress.values()) {
+                    questProgress.resetModified();
                 }
-            }.runTask(plugin);
+            else
+                new BukkitRunnable() {
+                    @Override
+                    public void run() {
+                        for (QuestProgress questProgress : questProgress.values()) {
+                            questProgress.resetModified();
+                        }
+                    }
+                }.runTask(plugin);
         } catch (IOException e) {
             e.printStackTrace();
         }


### PR DESCRIPTION
Added boolean check to saveToDisk to check if the plugin is disabling or not.
If check is 'true' the runTask is not called, but the content inside is.
If check is 'false' only the runTask is called.
I did not test it if it works in production. Guess one way to find out.