### PR TITLE
Add support for BentoBox levels

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,12 @@
             <url>http://dl.bintray.com/tastybento/maven-repo</url>
         </repository>
 
+        <!-- BentoBox -->
+        <repository>
+            <id>codemc-repo</id>
+            <url>https://repo.codemc.org/repository/maven-public/</url>
+        </repository>
+
         <!-- uSkyBlock -->
         <repository>
             <id>uSkyBlock-mvn-repo</id>
@@ -70,6 +76,14 @@
         <dependency>
             <groupId>com.wasteofplastic</groupId>
             <artifactId>askyblock</artifactId>
+            <version>LATEST</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- BentoBox (bSkyBlock) -->
+        <dependency>
+            <groupId>world.bentobox</groupId>
+            <artifactId>bentobox</artifactId>
             <version>LATEST</version>
             <scope>provided</scope>
         </dependency>

--- a/src/main/java/com/leonardobishop/quests/Quests.java
+++ b/src/main/java/com/leonardobishop/quests/Quests.java
@@ -146,6 +146,9 @@ public class Quests extends JavaPlugin {
             if (Bukkit.getPluginManager().isPluginEnabled("ASkyBlock")) {
                 taskTypeManager.registerTaskType(new ASkyBlockLevelType());
             }
+            if (Bukkit.getPluginManager().isPluginEnabled("BentoBox")) {
+                BentoBoxLevelTaskType.register(taskTypeManager);
+            }
             if (Bukkit.getPluginManager().isPluginEnabled("uSkyBlock")) {
                 taskTypeManager.registerTaskType(new uSkyBlockLevelType());
             }

--- a/src/main/java/com/leonardobishop/quests/quests/tasktypes/types/BentoBoxLevelTaskType.java
+++ b/src/main/java/com/leonardobishop/quests/quests/tasktypes/types/BentoBoxLevelTaskType.java
@@ -1,0 +1,89 @@
+package com.leonardobishop.quests.quests.tasktypes.types;
+
+import com.leonardobishop.quests.api.QuestsAPI;
+import com.leonardobishop.quests.player.QPlayer;
+import com.leonardobishop.quests.player.questprogressfile.QuestProgress;
+import com.leonardobishop.quests.player.questprogressfile.QuestProgressFile;
+import com.leonardobishop.quests.player.questprogressfile.TaskProgress;
+import com.leonardobishop.quests.quests.Quest;
+import com.leonardobishop.quests.quests.Task;
+import com.leonardobishop.quests.quests.tasktypes.ConfigValue;
+import com.leonardobishop.quests.quests.tasktypes.TaskType;
+import com.leonardobishop.quests.quests.tasktypes.TaskTypeManager;
+import org.bukkit.event.EventHandler;
+import world.bentobox.bentobox.BentoBox;
+import world.bentobox.bentobox.api.events.BentoBoxEvent;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicLong;
+
+public class BentoBoxLevelTaskType extends TaskType {
+
+    private List<ConfigValue> creatorConfigValues = new ArrayList<>();
+    private Field levelField = null;
+
+    public BentoBoxLevelTaskType() {
+        super("bentobox_level", "Rodney_Mc_Kay", "Reach a certain island level in the level addon for BentoBox.");
+        this.creatorConfigValues.add(new ConfigValue("level", true, "Minimum island level needed."));
+    }
+
+    @Override
+    public List<ConfigValue> getCreatorConfigValues() {
+        return creatorConfigValues;
+    }
+
+    public static void register(TaskTypeManager manager) {
+        if (BentoBox.getInstance().getAddonsManager().getAddonByName("Level").isPresent()) {
+            manager.registerTaskType(new BentoBoxLevelTaskType());
+        }
+    }
+
+    @EventHandler
+    public void onBentoBoxIslandLevelCalculated(BentoBoxEvent event) {
+        if ("IslandLevelCalculatedEvent".equalsIgnoreCase(event.getEventName())) {
+            QPlayer qPlayer = QuestsAPI.getPlayerManager().getPlayer((UUID) event.getKeyValues().get("targetPlayer"));
+            if (qPlayer == null) {
+                return;
+            }
+
+            QuestProgressFile questProgressFile = qPlayer.getQuestProgressFile();
+
+            for (Quest quest : super.getRegisteredQuests()) {
+                if (questProgressFile.hasStartedQuest(quest)) {
+                    QuestProgress questProgress = questProgressFile.getQuestProgress(quest);
+
+                    for (Task task : quest.getTasksOfType(super.getType())) {
+                        TaskProgress taskProgress = questProgress.getTaskProgress(task.getId());
+
+                        if (taskProgress.isCompleted()) {
+                            continue;
+                        }
+
+                        long islandLevelNeeded = (long) (int) task.getConfigValue("level");
+
+                        Object results = event.getKeyValues().get("results");
+
+                        try {
+                            if (levelField == null) {
+                                levelField = results.getClass().getDeclaredField("level");
+                                levelField.setAccessible(true);
+                            }
+
+                            AtomicLong level = (AtomicLong) levelField.get(results);
+                            taskProgress.setProgress(level.get());
+                        } catch (NoSuchFieldException | IllegalAccessException e) {
+                            e.printStackTrace();
+                        }
+
+                        if (((long) taskProgress.getProgress()) >= islandLevelNeeded) {
+                            taskProgress.setCompleted(true);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds "bentobox_level" tasktype, which checks (as the name suggests) for the island level on a bentobox server. BentoBox (BSkyBlock) is the successor of ASkyBlock.

Discord: Rodney#1203