### PR TITLE
Recoded placeholders system

### DIFF
--- a/src/main/java/com/leonardobishop/quests/api/QuestsPlaceholders.java
+++ b/src/main/java/com/leonardobishop/quests/api/QuestsPlaceholders.java
@@ -2,13 +2,15 @@ package com.leonardobishop.quests.api;
 
 import com.leonardobishop.quests.Quests;
 import com.leonardobishop.quests.api.enums.QuestStartResult;
+import com.leonardobishop.quests.obj.Options;
 import com.leonardobishop.quests.player.QPlayer;
+import com.leonardobishop.quests.quests.Category;
 import com.leonardobishop.quests.quests.Quest;
 import me.clip.placeholderapi.expansion.PlaceholderExpansion;
 import org.bukkit.entity.Player;
 
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
@@ -35,88 +37,229 @@ public class QuestsPlaceholders extends PlaceholderExpansion {
     }
 
     @Override
-    public String onPlaceholderRequest(Player player, String identifier) {
-        if (player == null)
-            return "";
-        QPlayer questPlayer = this.plugin.getPlayerManager().getPlayer(player.getUniqueId());
-        if (identifier.equals("current_quest_amount")) {
-            return String.valueOf(questPlayer.getQuestProgressFile().getStartedQuests().size());
-        }
-        if (identifier.equals("current_quest_names")) {
-            StringBuilder sb = new StringBuilder();
-            boolean first = true;
-            List<String> list = new ArrayList<>();
-            for (Quest currentQuests : questPlayer.getQuestProgressFile().getStartedQuests()) {
-                list.add(currentQuests.getDisplayNameStripped());
-            }
-            Collections.sort(list);
-            for (String questName : list) {
-                if (!first) {
-                    sb.append("\n");
+    public boolean persist() {
+        return true;
+    }
+
+    @Override
+    public String onPlaceholderRequest(Player p, String params) {
+        if (p == null || !p.isOnline())
+            return null;
+
+        String[] key = params.split("_", 5);
+        QPlayer questP = this.plugin.getPlayerManager().getPlayer(p.getUniqueId());
+
+        if (key[0].equals("all") || key[0].equals("completed") || key[0].equals("completedBefore") || key[0].equals("started") || key[0].equals("categories")) {
+            if (key.length == 1) {
+                switch (key[0]) {
+                    case "all":
+                        return String.valueOf(this.plugin.getQuestManager().getQuests().size());
+                    case "completed":
+                        return String.valueOf(questP.getQuestProgressFile().getQuestsProgress("completed").size());
+                    case "completedBefore":
+                        return String.valueOf(questP.getQuestProgressFile().getQuestsProgress("completedBefore").size());
+                    case "started":
+                        return String.valueOf(questP.getQuestProgressFile().getQuestsProgress("started").size());
+                    case "categories":
+                        return String.valueOf(this.plugin.getQuestManager().getCategories().size());
                 }
-                first = false;
-                sb.append(questName);
             }
-            return sb.toString();
+            if (key[1].equals("list") || key[1].equals("l")) {
+                String separator = ",";
+                if (!(key.length == 2)) {
+                    separator = key[2];
+                }
+
+                switch (key[0]) {
+                    case "all":
+                        return String.join(separator, this.plugin.getQuestManager().getQuests().toString());
+                    case "categories":
+                        return String.join(separator, this.plugin.getQuestManager().getCategories().toString());
+                    case "completed":
+                        List<String> listCompleted = new ArrayList<>();
+                        for (Quest qCompleted : questP.getQuestProgressFile().getQuestsProgress("completed")) {
+                            listCompleted.add(qCompleted.getDisplayNameStripped());
+                        }
+                        return String.join(separator, listCompleted);
+                    case "completedBefore":
+                        List<String> listCompletedBefore = new ArrayList<>();
+                        for (Quest qCompletedBefore : questP.getQuestProgressFile().getQuestsProgress("completedBefore")) {
+                            listCompletedBefore.add(qCompletedBefore.getDisplayNameStripped());
+                        }
+                        return String.join(separator, listCompletedBefore);
+                    case "started":
+                        List<String> listStarted = new ArrayList<>();
+                        for (Quest qStarted : questP.getQuestProgressFile().getQuestsProgress("started")) {
+                            listStarted.add(qStarted.getDisplayNameStripped());
+                        }
+                        return String.join(separator, listStarted);
+                }
+            }
+            return "null";
         }
-        if (identifier.startsWith("has_current_quest_")) {
-            String questId = identifier.substring(identifier.lastIndexOf("_") + 1);
-            for (Quest currentQuests : questPlayer.getQuestProgressFile().getStartedQuests()) {
-                if (currentQuests.getId().equals(questId)) {
+
+        if (key[0].startsWith("quest:") || key[0].startsWith("q:")) {
+            Quest questId = this.plugin.getQuestManager().getQuestById(key[0].substring(key[0].lastIndexOf(":") + 1));
+
+            if (key[1].equals("started") || key[1].equals("s")) {
+                if (questId != null && questP.getQuestProgressFile().getQuestProgress(questId).isStarted()) {
                     return "true";
                 }
+                return "false";
             }
-            return "false";
-        }
-        if (identifier.startsWith("has_completed_quest_")) {
-            String questId = identifier.substring(identifier.lastIndexOf("_") + 1);
-            Quest quest = this.plugin.getQuestManager().getQuestById(questId);
-            if (quest != null) {
-                if (questPlayer.getQuestProgressFile().getQuestProgress(quest).isCompleted())
-                    return "true";
-            }
-            return "false";
-        }
-        if (identifier.startsWith("has_completed_before_quest_")) {
-            String questId = identifier.substring(identifier.lastIndexOf("_") + 1);
-            Quest quest = this.plugin.getQuestManager().getQuestById(questId);
-            if (quest != null) {
-                if (questPlayer.getQuestProgressFile().getQuestProgress(quest).isCompletedBefore()) {
+            if (key[1].equals("completed") || key[1].equals("c")) {
+                if (questId != null && questP.getQuestProgressFile().getQuestProgress(questId).isCompleted()) {
                     return "true";
                 }
+                return "false";
             }
-            return "false";
-        }
-        if (identifier.startsWith("cooldown_time_remaining_")) {
-            String questId = identifier.substring(identifier.lastIndexOf("_") + 1);
-            Quest quest = this.plugin.getQuestManager().getQuestById(questId);
-            if (quest != null) {
-                if (questPlayer.getQuestProgressFile().getQuestProgress(quest).isCompleted()) {
-                    return this.plugin.convertToFormat(TimeUnit.SECONDS.convert(questPlayer.getQuestProgressFile().getCooldownFor(quest), TimeUnit.MILLISECONDS));
-                }
-            }
-            return this.plugin.convertToFormat(0);
-        }
-        if (identifier.startsWith("can_accept_quest_")) {
-            String questId = identifier.substring(identifier.lastIndexOf("_") + 1);
-            Quest quest = this.plugin.getQuestManager().getQuestById(questId);
-            if (quest != null) {
-                if (questPlayer.getQuestProgressFile().canStartQuest(quest) == QuestStartResult.QUEST_SUCCESS) {
+            if (key[1].equals("completedBefore") || key[1].equals("cB")) {
+                if (questId != null && questP.getQuestProgressFile().getQuestProgress(questId).isCompletedBefore()) {
                     return "true";
                 }
+                return "false";
             }
-            return "false";
-        }
-        if (identifier.startsWith("meets_requirements_")) {
-            String questId = identifier.substring(identifier.lastIndexOf("_") + 1);
-            Quest quest = this.plugin.getQuestManager().getQuestById(questId);
-            if (quest != null) {
-                if (questPlayer.getQuestProgressFile().hasMetRequirements(quest)) {
+            if (key[1].equals("completionDate")) {
+                if (questId != null && questP.getQuestProgressFile().getQuestProgress(questId).isCompleted()) {
+                    SimpleDateFormat sdf = new SimpleDateFormat("dd/MM/yyyy");
+                    return sdf.format(questP.getQuestProgressFile().getQuestProgress(questId).getCompletionDate());
+                }
+                return "Never";
+            }
+            if (key[1].equals("cooldown")) {
+                if (questId != null && questP.getQuestProgressFile().getQuestProgress(questId).isCompleted()) {
+                    String time = this.plugin.convertToFormat(TimeUnit.SECONDS.convert(questP.getQuestProgressFile().getCooldownFor(questId), TimeUnit.MILLISECONDS));
+                    if (time.startsWith("-")) {
+                        return "0";
+                    }
+                    return time;
+                }
+                return "0";
+            }
+            if (key[1].equals("canAccept")) {
+                if (questId != null && questP.getQuestProgressFile().canStartQuest(questId) == QuestStartResult.QUEST_SUCCESS) {
                     return "true";
                 }
+                return "false";
             }
-            return "false";
+            if (key[1].equals("meetsRequirements")) {
+                if (questId != null && questP.getQuestProgressFile().hasMetRequirements(questId)) {
+                    return "true";
+                }
+                return "false";
+            }
+            if (key[1].startsWith("task") || key[1].startsWith("t")) {
+                String[] t = key[1].split(":");
+                if (key[2].equals("progress") || key[2].equals("p")) {
+                    if (questId == null || questP.getQuestProgressFile().getQuestProgress(questId).getTaskProgress(t[1]).getProgress() == null) {
+                        return "0";
+                    }
+                    return String.valueOf(questP.getQuestProgressFile().getQuestProgress(questId).getTaskProgress(t[1]).getProgress());
+                }
+                if (key[2].equals("completed") || key[2].equals("c")) {
+                    if (questId == null || questP.getQuestProgressFile().getQuestProgress(questId).getTaskProgress(t[1]).isCompleted()) {
+                        return "true";
+                    }
+                    return "false";
+                }
+            }
+            return "null";
         }
-        return "";
+
+        if (key[0].startsWith("category:") || key[0].startsWith("c:")) {
+            if (!Options.CATEGORIES_ENABLED.getBooleanValue()) {
+                return "Categories Disabled";
+            }
+            Category categoryId = this.plugin.getQuestManager().getCategoryById(key[0].substring(key[0].lastIndexOf(":") + 1));
+            if (key.length == 2) {
+                switch (key[1]) {
+                    case "all":
+                    case "a":
+                        return String.valueOf(categoryId.getRegisteredQuestIds().size());
+                    case "completed":
+                    case "c":
+                        return String.valueOf(getCategoryQuests(questP, categoryId, "completed").size());
+                    case "completedBefore":
+                    case "cB":
+                        return String.valueOf(getCategoryQuests(questP, categoryId, "completedBefore").size());
+                    case "started":
+                    case "s":
+                        return String.valueOf(getCategoryQuests(questP, categoryId, "started").size());
+                }
+            }
+            if (key[2].equals("list") || key[2].equals("l")) {
+                String separator = ",";
+                if (!(key.length == 3)) {
+                    separator = key[3];
+                }
+
+                switch (key[1]) {
+                    case "all":
+                    case "a":
+                        List<String> listAll = new ArrayList<>();
+                        for (Quest qCompleted : getCategoryQuests(questP, categoryId, "all")) {
+                            listAll.add(qCompleted.getDisplayNameStripped());
+                        }
+                        return String.join(separator, listAll);
+                    case "completed":
+                    case "c":
+                        List<String> listCompleted = new ArrayList<>();
+                        for (Quest qCompleted : getCategoryQuests(questP, categoryId, "completed")) {
+                            listCompleted.add(qCompleted.getDisplayNameStripped());
+                        }
+                        return String.join(separator, listCompleted);
+                    case "completedBefore":
+                    case "cB":
+                        List<String> listCompletedBefore = new ArrayList<>();
+                        for (Quest qCompletedBefore : getCategoryQuests(questP, categoryId, "completedBefore")) {
+                            listCompletedBefore.add(qCompletedBefore.getDisplayNameStripped());
+                        }
+                        return String.join(separator, listCompletedBefore);
+                    case "started":
+                    case "s":
+                        List<String> listStarted = new ArrayList<>();
+                        for (Quest qStarted : getCategoryQuests(questP, categoryId, "started")) {
+                            listStarted.add(qStarted.getDisplayNameStripped());
+                        }
+                        return String.join(separator, listStarted);
+                }
+            }
+            return "null";
+        }
+        return null;
+    }
+
+    public List<Quest> getCategoryQuests(QPlayer questP, Category category, String type) {
+        List<Quest> CategoryQuests = new ArrayList<>();
+        if (type.equals("all")) {
+            for (String cQuests : category.getRegisteredQuestIds()) {
+                CategoryQuests.add(plugin.getQuestManager().getQuestById(cQuests));
+            }
+        }
+        if (type.equals("completed")) {
+            for (String cQuests : category.getRegisteredQuestIds()) {
+                Quest quest = plugin.getQuestManager().getQuestById(cQuests);
+                if (questP.getQuestProgressFile().getQuestProgress(quest).isCompleted()) {
+                    CategoryQuests.add(quest);
+                }
+            }
+        }
+        if (type.equals("completedBefore")) {
+            for (String cQuests : category.getRegisteredQuestIds()) {
+                Quest quest = plugin.getQuestManager().getQuestById(cQuests);
+                if (questP.getQuestProgressFile().getQuestProgress(quest).isCompletedBefore()) {
+                    CategoryQuests.add(quest);
+                }
+            }
+        }
+        if (type.equals("started")) {
+            for (String cQuests : category.getRegisteredQuestIds()) {
+                Quest quest = plugin.getQuestManager().getQuestById(cQuests);
+                if (questP.getQuestProgressFile().getQuestProgress(quest).isStarted()) {
+                    CategoryQuests.add(quest);
+                }
+            }
+        }
+        return CategoryQuests;
     }
 }

--- a/src/main/java/com/leonardobishop/quests/player/questprogressfile/QuestProgressFile.java
+++ b/src/main/java/com/leonardobishop/quests/player/questprogressfile/QuestProgressFile.java
@@ -237,6 +237,32 @@ public class QuestProgressFile {
         }
         return startedQuests;
     }
+    
+    public List<Quest> getQuestsProgress(String type) {
+        List<Quest> QuestsProgress = new ArrayList<>();
+        if (type.equals("completed")) {
+            for (QuestProgress qProgress : questProgress.values()) {
+                if (qProgress.isCompleted()) {
+                    QuestsProgress.add(plugin.getQuestManager().getQuestById(qProgress.getQuestId()));
+                }
+            }
+        }
+        if (type.equals("completedBefore")) {
+            for (QuestProgress qProgress : questProgress.values()) {
+                if (qProgress.isCompletedBefore()) {
+                    QuestsProgress.add(plugin.getQuestManager().getQuestById(qProgress.getQuestId()));
+                }
+            }
+        }
+        if (type.equals("started")) {
+            for (QuestProgress qProgress : questProgress.values()) {
+                if (qProgress.isStarted()) {
+                    QuestsProgress.add(plugin.getQuestManager().getQuestById(qProgress.getQuestId()));
+                }
+            }
+        }
+        return QuestsProgress;
+    }
 
     /**
      * Gets all the quest progress that it has ever encountered.
@@ -368,4 +394,3 @@ public class QuestProgressFile {
     }
 
 }
-


### PR DESCRIPTION
Not worry about bugs, i tested everything.
I added getQuestsProgress to QuestProgressFile.java but i not deleted getStartedQuests because it could break something.
The new and better placeholders are:
Tip: < > is a required entry while [ ] is not required

For total data:
**%quests_<all/completed/completedBefore/started/categories>_ [list/l]_[separator]>%**
Examples: (You can experiment with different combinations)
* %quests_started% return the number of started quests.
* %quests_completed_list% return a list comma-separated of completed quests.
* %quests_categories_list_-% return a list of all categories separated by "-".

For quest data:
**%quests_<quest/q>:questId_<[started/s]/[completed/c]/[completedBefore/cB]/completionDate/cooldown/canAccept/meetsRequirements>%**
Examples: (You can experiment with different combinations)
* %quests_quest:MineStone_completed% return true/false depending if you completed the quest "MineStone".
* %quests_q:PlaceBlocks_completionDate% return the completion date in format dd/MM/yyyy, if you never completed return "Never".

For task data:
**%quests_<quest/q>:questId_ <task/t>:taskId_ <[progress/p]/[completed/c]>%**
Examples: (You can experiment with different combinations)
* %quests_q:MineStone_task:mining_progress% return the progress of the task "mining" in "MineStone" quest.
* %quests_q:MineStone_t:mining_completed% return true/false depending if you completed task "mining" in "MineStone" quest.

For category data:
**%quests_<category/c>:categoryId_ <[all/a]/[completed/c]/[completedBefore/cB]/[started/s]>_ [list/l]_ [separator]%**
Examples: (You can experiment with different combinations)
* %quests_category:Farming_all% return the number of quests in category "Farming".
* %quests_c:Farming_completed_list% return a list comma-separated of all completed quests in category "Farming".
+ %quests_cFarming_s_list_-% return a list of all started quests in category "Farming" separated by "-"