### PR TITLE
Cached config bools

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>com.leonardobishop</groupId>
     <artifactId>quests</artifactId>
     <!-- Note to future self: changing the version to something ending with a 0 will truncate it -->
-    <version>2.10.1</version>
+    <version>2.10.2</version>
     <name>Quests</name>
 
     <properties>

--- a/src/main/java/com/leonardobishop/quests/commands/CommandQuests.java
+++ b/src/main/java/com/leonardobishop/quests/commands/CommandQuests.java
@@ -65,6 +65,7 @@ public class CommandQuests implements CommandExecutor {
                     } else if (args[1].equalsIgnoreCase("reload")) {
                         plugin.reloadConfig();
                         plugin.reloadQuests();
+                        Options.clearBoolValues();
                         if (!plugin.getQuestsConfigLoader().getBrokenFiles().isEmpty()) {
                             sender.sendMessage(ChatColor.RED + "Quests has failed to load the following files:");
                             for (Map.Entry<String, QuestsConfigLoader.ConfigLoadError> entry : plugin.getQuestsConfigLoader().getBrokenFiles().entrySet()) {

--- a/src/main/java/com/leonardobishop/quests/obj/Options.java
+++ b/src/main/java/com/leonardobishop/quests/obj/Options.java
@@ -3,11 +3,13 @@ package com.leonardobishop.quests.obj;
 import com.leonardobishop.quests.Quests;
 import org.bukkit.ChatColor;
 
+import java.time.temporal.ValueRange;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 public enum Options {
-
     CATEGORIES_ENABLED("options.categories-enabled"),
     TRIM_GUI_SIZE("options.trim-gui-size"),
     QUESTS_START_LIMIT("options.quest-started-limit"),
@@ -21,6 +23,8 @@ public enum Options {
     GUITITLE_QUEST_CANCEL("options.guinames.quest-cancel"),
     ALLOW_QUEST_CANCEL("options.allow-quest-cancel"),
     QUEST_AUTOSTART("options.quest-autostart");
+
+    private static final Map<String, Boolean> cachedBools = new HashMap<>();
 
     private final String path;
 
@@ -37,7 +41,13 @@ public enum Options {
     }
 
     public boolean getBooleanValue() {
-        return Quests.get().getConfig().getBoolean(path);
+        Boolean val = cachedBools.get(path);
+        if (val != null) {
+            return val;
+        } else {
+            cachedBools.put(path, Quests.get().getConfig().getBoolean(path));
+            return getBooleanValue();
+        }
     }
 
     public List<String> getStringListValue() {
@@ -54,5 +64,9 @@ public enum Options {
             colored.add(ChatColor.translateAlternateColorCodes('&', line));
         }
         return colored;
+    }
+
+    public static void clearBoolValues() {
+        cachedBools.clear();
     }
 }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -4,7 +4,7 @@ name: Quests
 version: %PLUGIN_VERSION%
 
 main: com.leonardobishop.quests.Quests
-author: LMBishop
+authors: [LMBishop, Auxilor]
 softdepend: [ASkyBlock, uSkyBlock, Citizens, PlaceholderAPI]
 prefix: Quests
 api-version: "1.13" # allows new API features but Quests will still work pre-1.13


### PR DESCRIPTION
Extremely poor performance when combined with EcoEnchants was caused by not cached config bools. Fixed!