### PR TITLE
Display only unmet requirements

### DIFF
--- a/src/main/java/com/leonardobishop/quests/menu/element/QuestMenuElement.java
+++ b/src/main/java/com/leonardobishop/quests/menu/element/QuestMenuElement.java
@@ -46,7 +46,11 @@ public class QuestMenuElement extends MenuElement {
         if (!owner.getQuestProgressFile().hasMetRequirements(quest)) {
             List<String> quests = new ArrayList<>();
             for (String requirement : quest.getRequirements()) {
-                quests.add(plugin.getQuestManager().getQuestById(requirement).getDisplayNameStripped());
+                Quest requirementQuest = Quests.get().getQuestManager().getQuestById(requirement);
+                if (!owner.getQuestProgressFile().hasQuestProgress(requirementQuest) ||
+                        !owner.getQuestProgressFile().getQuestProgress(requirementQuest).isCompletedBefore()) {
+                    quests.add(requirementQuest.getDisplayNameStripped());
+                }
             }
             Map<String, String> placeholders = new HashMap<>();
             placeholders.put("{quest}", quest.getDisplayNameStripped());


### PR DESCRIPTION
This pull request changes the quests menu, so that on quests with requirements that haven't been met yet, only those quests are displayed as requirements that haven't already been completed. This makes it easier to see all the quests if there are lots of requirements.