### PR TITLE
Adding rank based active quest limits

### DIFF
--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/config/BukkitQuestsConfig.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/config/BukkitQuestsConfig.java
@@ -94,9 +94,10 @@ public class BukkitQuestsConfig implements QuestsConfig {
     }
 
     public int getQuestLimit(Player player) {
+        if (config.contains("options.quest-started-limit")) return config.getInt("options.quest-started-limit");
         int limit = getQuestLimit("default");
-        if(player != null) {
-            for (String rank : config.getConfigurationSection("options.quest-limit-multiple").getKeys(false)) {
+        if (player != null) {
+            for (String rank : config.getConfigurationSection("options.quest-limit").getKeys(false)) {
                 int newLimit = getQuestLimit(rank);
                 if (player.hasPermission("quests.limit." + rank) && (limit < newLimit))
                     limit = newLimit;
@@ -106,6 +107,6 @@ public class BukkitQuestsConfig implements QuestsConfig {
     }
 
     public int getQuestLimit(@NotNull String rank) {
-        return config.getInt("options.quest-limit-multiple." + rank, config.getInt("options.quest-limit-multiple.default", 2));
+        return config.getInt("options.quest-limit." + rank, config.getInt("options.quest-limit.default", 2));
     }
 }

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/config/BukkitQuestsConfig.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/config/BukkitQuestsConfig.java
@@ -11,7 +11,6 @@ import java.io.File;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 public class BukkitQuestsConfig implements QuestsConfig {
 

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/config/BukkitQuestsConfig.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/config/BukkitQuestsConfig.java
@@ -3,6 +3,7 @@ package com.leonardobishop.quests.bukkit.config;
 import com.leonardobishop.quests.bukkit.hook.itemgetter.ItemGetter;
 import com.leonardobishop.quests.common.config.QuestsConfig;
 import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.NotNull;
 
@@ -10,6 +11,7 @@ import java.io.File;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 public class BukkitQuestsConfig implements QuestsConfig {
 
@@ -90,5 +92,21 @@ public class BukkitQuestsConfig implements QuestsConfig {
 
     public ItemStack getItem(@NotNull String path) {
         return new ItemStack(cachedItemStacks.computeIfAbsent(path, s -> itemGetter.getItem(path, config)));
+    }
+
+    public int getQuestLimit(Player player) {
+        int limit = getQuestLimit("default");
+        if(player != null) {
+            for (String rank : config.getConfigurationSection("options.quest-limit-multiple").getKeys(false)) {
+                int newLimit = getQuestLimit(rank);
+                if (player.hasPermission("quests.limit." + rank) && (limit < newLimit))
+                    limit = newLimit;
+            }
+        }
+        return limit;
+    }
+
+    public int getQuestLimit(@NotNull String rank) {
+        return config.getInt("options.quest-limit-multiple." + rank, config.getInt("options.quest-limit-multiple.default", 2));
     }
 }

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/questcontroller/NormalQuestController.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/questcontroller/NormalQuestController.java
@@ -63,7 +63,7 @@ public class NormalQuestController implements QuestController {
                     // This one is hacky
                     break;
                 case QUEST_LIMIT_REACHED:
-                    questResultMessage = Messages.QUEST_START_LIMIT.getMessage().replace("{limit}", String.valueOf(config.getInt("options.quest-started-limit")));
+                    questResultMessage = Messages.QUEST_START_LIMIT.getMessage().replace("{limit}", String.valueOf(config.getQuestLimit(player)));
                     break;
                 case QUEST_ALREADY_COMPLETED:
                     questResultMessage = Messages.QUEST_START_DISABLED.getMessage();
@@ -184,7 +184,7 @@ public class NormalQuestController implements QuestController {
                 return QuestStartResult.NO_PERMISSION_FOR_CATEGORY;
             }
         }
-        if (!config.getBoolean("options.quest-autostart") && getStartedQuestsForPlayer(qPlayer).size() >= config.getInt("options.quest-started-limit")) {
+        if (!config.getBoolean("options.quest-autostart") && getStartedQuestsForPlayer(qPlayer).size() >= config.getQuestLimit(p)) {
             return QuestStartResult.QUEST_LIMIT_REACHED;
         }
         return QuestStartResult.QUEST_SUCCESS;

--- a/bukkit/src/main/resources/resources/bukkit/config.yml
+++ b/bukkit/src/main/resources/resources/bukkit/config.yml
@@ -150,16 +150,14 @@ options:
   trim-gui-size: true
   # Enable/disable titles
   titles-enabled: true
-
   # Allow players to have multiple active quests.
   # You can set the default number of quests using the 'default' rank below.
   # To grant different quest limits to different people, you can define a 'quest-rank'
   # Create the 'quest-rank' below, and give the matching permission: quests.limit.<quest-rank>
-  quest-limit-multiple:
+  quest-limit:
     default: 2
     #vip: 5
     #staff: 10
-
   # Allow players to cancel a quest (you may want to remove the cancel instructions in the global item lore)
   allow-quest-cancel: true
   # Allow players to track a quest (you may want to remove the tracking instructions in the global item lore)

--- a/bukkit/src/main/resources/resources/bukkit/config.yml
+++ b/bukkit/src/main/resources/resources/bukkit/config.yml
@@ -150,8 +150,16 @@ options:
   trim-gui-size: true
   # Enable/disable titles
   titles-enabled: true
-  # Players cannot start any more quests than this at a single time
-  quest-started-limit: 2
+
+  # Allow players to have multiple active quests.
+  # You can set the default number of quests using the 'default' rank below.
+  # To grant different quest limits to different people, you can define a 'quest-rank'
+  # Create the 'quest-rank' below, and give the matching permission: quests.limit.<quest-rank>
+  quest-limit-multiple:
+    default: 2
+    #vip: 5
+    #staff: 10
+
   # Allow players to cancel a quest (you may want to remove the cancel instructions in the global item lore)
   allow-quest-cancel: true
   # Allow players to track a quest (you may want to remove the tracking instructions in the global item lore)


### PR DESCRIPTION
Adds in a feature similar to EssentialsX's multihome setting, allowing different ranks to have different limits of starting quests. Similar to request made in #91 but modified via name based permissions stored by the plugin.

Do note that this will require regeneration of the old config file (not sure how you go about that) as it searches for the new configuration section.

Also, this is my first pull request so my apologies for any problems. I tried to follow the contribution guidelines and guidance set forth in the CONTRIBUTING.md :) 

Let me know if I need to make any changes/any issues you see with my implementation!