### PR TITLE
Add option to ignore Essentials-AFK players for PlaytimeTaskType

### DIFF
--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/BukkitQuestsPlugin.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/BukkitQuestsPlugin.java
@@ -6,6 +6,8 @@ import com.leonardobishop.quests.bukkit.config.BukkitQuestsConfig;
 import com.leonardobishop.quests.bukkit.config.BukkitQuestsLoader;
 import com.leonardobishop.quests.bukkit.hook.coreprotect.AbstractCoreProtectHook;
 import com.leonardobishop.quests.bukkit.hook.coreprotect.CoreProtectHook;
+import com.leonardobishop.quests.bukkit.hook.essentials.AbstractEssentialsHook;
+import com.leonardobishop.quests.bukkit.hook.essentials.EssentialsHook;
 import com.leonardobishop.quests.bukkit.hook.itemgetter.ItemGetter;
 import com.leonardobishop.quests.bukkit.hook.itemgetter.ItemGetterLatest;
 import com.leonardobishop.quests.bukkit.hook.itemgetter.ItemGetter_1_13;
@@ -111,6 +113,7 @@ public class BukkitQuestsPlugin extends JavaPlugin implements Quests {
     private MenuController menuController;
     private AbstractPlaceholderAPIHook placeholderAPIHook;
     private AbstractCoreProtectHook coreProtectHook;
+    private AbstractEssentialsHook essentialsHook;
     private ItemGetter itemGetter;
     private Title titleHandle;
 
@@ -255,6 +258,10 @@ public class BukkitQuestsPlugin extends JavaPlugin implements Quests {
 
         if (Bukkit.getPluginManager().isPluginEnabled("CoreProtect")) {
             this.coreProtectHook = new CoreProtectHook();
+        }
+
+        if (Bukkit.getPluginManager().isPluginEnabled("Essentials")) {
+            this.essentialsHook = new EssentialsHook();
         }
 
         // Start quests update checker
@@ -526,6 +533,10 @@ public class BukkitQuestsPlugin extends JavaPlugin implements Quests {
 
     public @Nullable AbstractCoreProtectHook getCoreProtectHook() {
         return coreProtectHook;
+    }
+
+    public @Nullable AbstractEssentialsHook getEssentialsHook() {
+        return essentialsHook;
     }
 
     public ItemGetter getItemGetter() {

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/hook/essentials/AbstractEssentialsHook.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/hook/essentials/AbstractEssentialsHook.java
@@ -1,0 +1,13 @@
+package com.leonardobishop.quests.bukkit.hook.essentials;
+
+import org.bukkit.entity.Player;
+
+public interface AbstractEssentialsHook {
+    /**
+     * Check whether or not the passed player is marked AFK by Essentials
+     *
+     * @param player the block
+     * @return true if afk, false otherwise
+     */
+    boolean isAfk(Player player);
+}

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/hook/essentials/EssentialsHook.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/hook/essentials/EssentialsHook.java
@@ -1,0 +1,19 @@
+package com.leonardobishop.quests.bukkit.hook.essentials;
+
+import com.earth2me.essentials.Essentials;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+
+public class EssentialsHook implements AbstractEssentialsHook {
+
+    private final Essentials ess;
+
+    public EssentialsHook() {
+        ess = ((Essentials) Bukkit.getPluginManager().getPlugin("Essentials"));
+    }
+
+    @Override
+    public boolean isAfk(Player player) {
+        return ess.getUser(player).isAfk();
+    }
+}

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/type/PlaytimeTaskType.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/type/PlaytimeTaskType.java
@@ -1,6 +1,5 @@
 package com.leonardobishop.quests.bukkit.tasktype.type;
 
-import com.earth2me.essentials.Essentials;
 import com.leonardobishop.quests.bukkit.BukkitQuestsPlugin;
 import com.leonardobishop.quests.bukkit.tasktype.BukkitTaskType;
 import com.leonardobishop.quests.bukkit.util.TaskUtils;
@@ -41,8 +40,6 @@ public final class PlaytimeTaskType extends BukkitTaskType {
 
     @Override
     public void onReady() {
-        boolean ignoreAFK = plugin.getQuestsConfig().getBoolean("options.playtime-ignores-afk", false);
-        Essentials ess = (Essentials) Bukkit.getPluginManager().getPlugin("Essentials");
         if (this.poll == null) {
             this.poll = new BukkitRunnable() {
                 @Override
@@ -52,14 +49,16 @@ public final class PlaytimeTaskType extends BukkitTaskType {
                         if (qPlayer == null) {
                             continue;
                         }
-                        if (ignoreAFK && ess != null && ess.getUser(player).isAfk()) {
-                            continue; // user is AFK so we will not track progress
-                        }
 
                         for (Quest quest : PlaytimeTaskType.super.getRegisteredQuests()) {
                             if (qPlayer.hasStartedQuest(quest)) {
                                 QuestProgress questProgress = qPlayer.getQuestProgressFile().getQuestProgress(quest);
                                 for (Task task : quest.getTasksOfType(PlaytimeTaskType.super.getType())) {
+                                    if ((boolean) task.getConfigValue("ignore-afk", false)
+                                            && plugin.getEssentialsHook() != null
+                                            && plugin.getEssentialsHook().isAfk(player)) {
+                                        continue;
+                                    }
                                     if (!TaskUtils.validateWorld(player, task)) continue;
 
                                     TaskProgress taskProgress = questProgress.getTaskProgress(task.getId());

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/type/PlaytimeTaskType.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/type/PlaytimeTaskType.java
@@ -1,5 +1,6 @@
 package com.leonardobishop.quests.bukkit.tasktype.type;
 
+import com.earth2me.essentials.Essentials;
 import com.leonardobishop.quests.bukkit.BukkitQuestsPlugin;
 import com.leonardobishop.quests.bukkit.tasktype.BukkitTaskType;
 import com.leonardobishop.quests.bukkit.util.TaskUtils;
@@ -40,6 +41,8 @@ public final class PlaytimeTaskType extends BukkitTaskType {
 
     @Override
     public void onReady() {
+        boolean ignoreAFK = plugin.getQuestsConfig().getBoolean("options.playtime-ignores-afk", false);
+        Essentials ess = (Essentials) Bukkit.getPluginManager().getPlugin("Essentials");
         if (this.poll == null) {
             this.poll = new BukkitRunnable() {
                 @Override
@@ -48,6 +51,9 @@ public final class PlaytimeTaskType extends BukkitTaskType {
                         QPlayer qPlayer = plugin.getPlayerManager().getPlayer(player.getUniqueId());
                         if (qPlayer == null) {
                             continue;
+                        }
+                        if (ignoreAFK && ess != null && ess.getUser(player).isAfk()) {
+                            continue; // user is AFK so we will not track progress
                         }
 
                         for (Quest quest : PlaytimeTaskType.super.getRegisteredQuests()) {

--- a/bukkit/src/main/resources/resources/bukkit/config.yml
+++ b/bukkit/src/main/resources/resources/bukkit/config.yml
@@ -150,6 +150,8 @@ options:
   trim-gui-size: true
   # Enable/disable titles
   titles-enabled: true
+  # Should the playtime task type ignore users who are marked AFK by Essentials
+  playtime-ignores-afk: false
   # Allow players to have multiple active quests.
   # You can set the default number of quests using the 'default' rank below.
   # To grant different quest limits to different people, you can define a 'quest-rank'

--- a/bukkit/src/main/resources/resources/bukkit/config.yml
+++ b/bukkit/src/main/resources/resources/bukkit/config.yml
@@ -150,8 +150,6 @@ options:
   trim-gui-size: true
   # Enable/disable titles
   titles-enabled: true
-  # Should the playtime task type ignore users who are marked AFK by Essentials
-  playtime-ignores-afk: false
   # Allow players to have multiple active quests.
   # You can set the default number of quests using the 'default' rank below.
   # To grant different quest limits to different people, you can define a 'quest-rank'


### PR DESCRIPTION
The server I'm working for noticed that the PlaytimeTaskType grants users time even if they're marked AFK, which (for our purposes at least) defeats the point of the playtime quest. Decided to hook into Essentials (which is already a Quests dependency) and exempt users who are AFK at the time of the PlaytimeTask increment from getting time added to their quest progress.

Additionally added a config option to enable this (whose fallback is false, that way this feature isn't automatically on in old users' configs).

I also understand if you don't pull this in, as it offers a solution to a very-very specific problem, but I'm thought hey, _someone_ out there might find it useful  :) 