### PR TITLE
Added command to open the started Quests GUI via console/admin for ot…

### DIFF
--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/command/AdminOpenguiCommandSwitcher.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/command/AdminOpenguiCommandSwitcher.java
@@ -15,11 +15,13 @@ public class AdminOpenguiCommandSwitcher extends CommandSwitcher {
 
         super.subcommands.put("quest", new AdminOpenguiQuestCommandHandler(plugin));
         super.subcommands.put("category", new AdminOpenguiCategoryCommandHandler(plugin));
+        super.subcommands.put("started", new AdminOpenguiStartedCommandHandler(plugin));
 
         super.aliases.put("q", "quest");
         super.aliases.put("quests", "quest");
         super.aliases.put("c", "category");
         super.aliases.put("categories", "category");
+        super.aliases.put("s", "started");
     }
 
     @Override
@@ -29,6 +31,8 @@ public class AdminOpenguiCommandSwitcher extends CommandSwitcher {
         sender.sendMessage(ChatColor.GRAY + "The following commands are available: ");
         sender.sendMessage(ChatColor.DARK_GRAY + " * " + ChatColor.RED + "/quests a opengui q/quest <player> " + ChatColor.DARK_GRAY + ": forcefully show" +
                 " quests for player");
+        sender.sendMessage(ChatColor.DARK_GRAY + " * " + ChatColor.RED + "/quests a opengui s/started <player> " + ChatColor.DARK_GRAY + ": forcefully show" +
+                " started quests for player");
         sender.sendMessage(ChatColor.DARK_GRAY + " * " + ChatColor.RED + "/quests a opengui c/category <player> <category> " + ChatColor.DARK_GRAY + ": " +
                 "forcefully " +
                 "open category by ID for player");

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/command/AdminOpenguiStartedCommandHandler.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/command/AdminOpenguiStartedCommandHandler.java
@@ -1,0 +1,54 @@
+package com.leonardobishop.quests.bukkit.command;
+
+import com.leonardobishop.quests.bukkit.BukkitQuestsPlugin;
+import com.leonardobishop.quests.bukkit.util.Messages;
+import com.leonardobishop.quests.common.player.QPlayer;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Collections;
+import java.util.List;
+
+public class AdminOpenguiStartedCommandHandler implements CommandHandler {
+
+    private final BukkitQuestsPlugin plugin;
+
+    public AdminOpenguiStartedCommandHandler(BukkitQuestsPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public void handle(CommandSender sender, String[] args) {
+        if (args.length > 3) {
+            Player player = Bukkit.getPlayer(args[3]);
+            if (player != null) {
+                QPlayer qPlayer = plugin.getPlayerManager().getPlayer(player.getUniqueId());
+                if (qPlayer != null) {
+                    plugin.getMenuController().openStartedQuests(qPlayer);
+                    Messages.COMMAND_QUEST_OPENSTARTED_ADMIN_SUCCESS.send(sender,
+                            "{player}", player.getName());
+                    return;
+                }
+            }
+            Messages.COMMAND_QUEST_ADMIN_PLAYERNOTFOUND.send(sender, "{player}", args[3]);
+        }
+
+        sender.sendMessage(ChatColor.RED + "/quests a/admin opengui s/started <player>");
+    }
+
+    @Override
+    public List<String> tabComplete(CommandSender sender, String[] args) {
+        if (args.length == 4) {
+            return null;
+        }
+        return Collections.emptyList();
+    }
+
+    @Override
+    public @Nullable String getPermission() {
+        return "quests.admin";
+    }
+}

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/util/Messages.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/util/Messages.java
@@ -39,6 +39,7 @@ public enum Messages {
     COMMAND_QUEST_GENERAL_DOESNTEXIST("messages.command-quest-general-doesntexist", "&7The specified quest '&c{quest}&7' does not exist."),
     COMMAND_QUEST_OPENCATEGORY_ADMIN_SUCCESS("messages.command-quest-opencategory-admin-success", "&7Opened category &c{category} &7for player &c{player}&7."),
     COMMAND_QUEST_OPENQUESTS_ADMIN_SUCCESS("messages.command-quest-openquests-admin-success", "&7Opened Quest GUI for player &c{player}&7."),
+    COMMAND_QUEST_OPENSTARTED_ADMIN_SUCCESS("messages.command-quest-openstarted-admin-success", "&7Opened started Quest GUI for player &c{player}&7."),
     COMMAND_QUEST_ADMIN_PLAYERNOTFOUND("messages.command-quest-admin-playernotfound", "&7Player '&c{player}&7' could not be found."),
     COMMAND_CATEGORY_OPEN_DOESNTEXIST("messages.command-category-open-doesntexist", "&7The specified category '&c{category}&7' does not exist."),
     COMMAND_CATEGORY_OPEN_DISABLED("messages.command-category-open-disabled", "&7Categories are disabled."),

--- a/bukkit/src/main/resources/resources/bukkit/config.yml
+++ b/bukkit/src/main/resources/resources/bukkit/config.yml
@@ -333,6 +333,7 @@ messages:
   command-category-open-doesntexist: "&7The specified category '&c{category}&7' does not exist."
   command-quest-admin-playernotfound: "&7Player '&c{player}&7' could not be found."
   command-quest-openquests-admin-success: "&7Opened Quest GUI for player &c{player}&7."
+  command-quest-openstarted-admin-success: "&7Opened started Quest GUI for player &c{player}&7."
   command-quest-opencategory-admin-success: "&7Opened category &c{category} &7for player &c{player}&7."
   command-taskview-admin-fail: "&7Task type '&c{task}&7' does not exist."
   beta-reminder: "&cQuests > &7Reminder: you are currently using a &cbeta &7version of Quests. Please send bug reports to https://github.com/LMBishop/Quests/issues and check for updates regularly using &c/quests admin update&7!"


### PR DESCRIPTION
I was missing the option to open the "started quest" menu via admin/console, so I've added it now. 