### PR TITLE
Add mode config option to farming task type, 

### DIFF
--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/type/CraftingTaskType.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/type/CraftingTaskType.java
@@ -20,6 +20,7 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.inventory.ClickType;
 import org.bukkit.event.inventory.CraftItemEvent;
+import org.bukkit.event.inventory.InventoryAction;
 import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.NotNull;
@@ -59,7 +60,8 @@ public final class CraftingTaskType extends BukkitTaskType {
         if (event.getClickedInventory() == null
                 || (event.getClickedInventory().getType() != InventoryType.CRAFTING && event.getClickedInventory().getType() != InventoryType.WORKBENCH)
                 || event.getSlotType() != InventoryType.SlotType.RESULT
-                || event.getCurrentItem() == null) {
+                || event.getCurrentItem() == null
+                || event.getAction() == InventoryAction.NOTHING) {
             return;
         }
 

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/type/FarmingCertainTaskType.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/type/FarmingCertainTaskType.java
@@ -83,17 +83,13 @@ public final class FarmingCertainTaskType extends BukkitTaskType {
         }
     }
 
-    private boolean validateCrop(Block block) {
+    private void handle(Player player, Block block, String mode) {
         if (!(block.getState().getBlockData() instanceof Ageable)) {
-            return false;
+            return;
         }
 
         Ageable crop = (Ageable) block.getState().getBlockData();
-        return crop.getAge() == crop.getMaximumAge();
-    }
-
-    private void handle(Player player, Block block, String mode) {
-        if (!validateCrop(block)) {
+        if (crop.getAge() != crop.getMaximumAge()) {
             return;
         }
 

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/type/FarmingCertainTaskType.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/type/FarmingCertainTaskType.java
@@ -83,13 +83,17 @@ public final class FarmingCertainTaskType extends BukkitTaskType {
         }
     }
 
-    private void handle(Player player, Block block, String mode) {
+    private boolean validateCrop(Block block) {
         if (!(block.getState().getBlockData() instanceof Ageable)) {
-            return;
+            return false;
         }
 
         Ageable crop = (Ageable) block.getState().getBlockData();
-        if (crop.getAge() != crop.getMaximumAge()) {
+        return crop.getAge() == crop.getMaximumAge();
+    }
+
+    private void handle(Player player, Block block, String mode) {
+        if (!validateCrop(block)) {
             return;
         }
 

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/type/FarmingCertainTaskType.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/type/FarmingCertainTaskType.java
@@ -65,7 +65,6 @@ public final class FarmingCertainTaskType extends BukkitTaskType {
         return problems;
     }
 
-    @SuppressWarnings("deprecation")
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onBlockBreak(BlockBreakEvent event) {
         if (!(event.getBlock().getState().getBlockData() instanceof Ageable)) {

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/type/FarmingCertainTaskType.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/type/FarmingCertainTaskType.java
@@ -117,18 +117,18 @@ public final class FarmingCertainTaskType extends BukkitTaskType {
                     }
 
                     if (matchBlock(task, block)) {
-                        int brokenBlocksNeeded = (int) task.getConfigValue("amount");
+                        int blocksNeeded = (int) task.getConfigValue("amount");
 
-                        int progressBlocksBroken;
+                        int progressBlocks;
                         if (taskProgress.getProgress() == null) {
-                            progressBlocksBroken = 0;
+                            progressBlocks = 0;
                         } else {
-                            progressBlocksBroken = (int) taskProgress.getProgress();
+                            progressBlocks = (int) taskProgress.getProgress();
                         }
 
-                        taskProgress.setProgress(progressBlocksBroken + 1);
+                        taskProgress.setProgress(progressBlocks + 1);
 
-                        if (((int) taskProgress.getProgress()) >= brokenBlocksNeeded) {
+                        if (((int) taskProgress.getProgress()) >= blocksNeeded) {
                             taskProgress.setCompleted(true);
                         }
                     }

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/type/FarmingTaskType.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/type/FarmingTaskType.java
@@ -56,13 +56,17 @@ public final class FarmingTaskType extends BukkitTaskType {
         }
     }
 
-    private void handle(Player player, Block block, String mode) {
+    private boolean validateCrop(Block block) {
         if (!(block.getState().getBlockData() instanceof Ageable)) {
-            return;
+            return false;
         }
 
         Ageable crop = (Ageable) block.getState().getBlockData();
-        if (crop.getAge() != crop.getMaximumAge()) {
+        return crop.getAge() == crop.getMaximumAge();
+    }
+
+    private void handle(Player player, Block block, String mode) {
+        if (!validateCrop(block)) {
             return;
         }
 

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/type/FarmingTaskType.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/type/FarmingTaskType.java
@@ -56,17 +56,13 @@ public final class FarmingTaskType extends BukkitTaskType {
         }
     }
 
-    private boolean validateCrop(Block block) {
+    private void handle(Player player, Block block, String mode) {
         if (!(block.getState().getBlockData() instanceof Ageable)) {
-            return false;
+            return;
         }
 
         Ageable crop = (Ageable) block.getState().getBlockData();
-        return crop.getAge() == crop.getMaximumAge();
-    }
-
-    private void handle(Player player, Block block, String mode) {
-        if (!validateCrop(block)) {
+        if (crop.getAge() != crop.getMaximumAge()) {
             return;
         }
 

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/type/FarmingTaskType.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/type/FarmingTaskType.java
@@ -36,7 +36,6 @@ public final class FarmingTaskType extends BukkitTaskType {
         return problems;
     }
 
-    @SuppressWarnings("deprecation")
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onBlockBreak(BlockBreakEvent event) {
         if (!(event.getBlock().getState().getBlockData() instanceof Ageable)) {

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/type/FarmingTaskType.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/type/FarmingTaskType.java
@@ -9,9 +9,13 @@ import com.leonardobishop.quests.common.player.questprogressfile.QuestProgress;
 import com.leonardobishop.quests.common.player.questprogressfile.TaskProgress;
 import com.leonardobishop.quests.common.quest.Quest;
 import com.leonardobishop.quests.common.quest.Task;
+import org.bukkit.Bukkit;
+import org.bukkit.block.Block;
 import org.bukkit.block.data.Ageable;
+import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockBreakEvent;
 import org.jetbrains.annotations.NotNull;
 
@@ -24,8 +28,13 @@ public final class FarmingTaskType extends BukkitTaskType {
     private final BukkitQuestsPlugin plugin;
 
     public FarmingTaskType(BukkitQuestsPlugin plugin) {
-        super("farming", TaskUtils.TASK_ATTRIBUTION_STRING, "Break a set amount of any crop.");
+        super("farming", TaskUtils.TASK_ATTRIBUTION_STRING, "Break or harvest a set amount of any crop.");
         this.plugin = plugin;
+
+        try {
+            Class.forName("org.bukkit.event.player.PlayerHarvestBlockEvent");
+            plugin.getServer().getPluginManager().registerEvents(new FarmingTaskType.HarvestBlockListener(), plugin);
+        } catch (ClassNotFoundException ignored) { } // server version cannot support event
     }
 
     @Override
@@ -38,17 +47,28 @@ public final class FarmingTaskType extends BukkitTaskType {
 
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onBlockBreak(BlockBreakEvent event) {
-        if (!(event.getBlock().getState().getBlockData() instanceof Ageable)) {
+        handle(event.getPlayer(), event.getBlock(), "break");
+    }
+
+    private final class HarvestBlockListener implements Listener {
+        @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+        public void onHarvestBlock(org.bukkit.event.player.PlayerHarvestBlockEvent event) {
+            handle(event.getPlayer(), event.getHarvestedBlock(), "harvest");
+        }
+    }
+
+    private void handle(Player player, Block block, String mode) {
+        if (!(block.getState().getBlockData() instanceof Ageable)) {
             return;
         }
 
-        QPlayer qPlayer = plugin.getPlayerManager().getPlayer(event.getPlayer().getUniqueId());
-        if (qPlayer == null) {
-            return;
-        }
-
-        Ageable crop = (Ageable) event.getBlock().getState().getBlockData();
+        Ageable crop = (Ageable) block.getState().getBlockData();
         if (crop.getAge() != crop.getMaximumAge()) {
+            return;
+        }
+
+        QPlayer qPlayer = plugin.getPlayerManager().getPlayer(player.getUniqueId());
+        if (qPlayer == null) {
             return;
         }
 
@@ -57,7 +77,7 @@ public final class FarmingTaskType extends BukkitTaskType {
                 QuestProgress questProgress = qPlayer.getQuestProgressFile().getQuestProgress(quest);
 
                 for (Task task : quest.getTasksOfType(super.getType())) {
-                    if (!TaskUtils.validateWorld(event.getPlayer(), task)) continue;
+                    if (!TaskUtils.validateWorld(player, task)) continue;
 
                     TaskProgress taskProgress = questProgress.getTaskProgress(task.getId());
 
@@ -65,18 +85,23 @@ public final class FarmingTaskType extends BukkitTaskType {
                         continue;
                     }
 
-                    int brokenBlocksNeeded = (int) task.getConfigValue("amount");
-
-                    int progressBlocksBroken;
-                    if (taskProgress.getProgress() == null) {
-                        progressBlocksBroken = 0;
-                    } else {
-                        progressBlocksBroken = (int) taskProgress.getProgress();
+                    if (task.getConfigValue("mode") != null
+                            && !mode.equalsIgnoreCase(task.getConfigValue("mode").toString())) {
+                        continue;
                     }
 
-                    taskProgress.setProgress(progressBlocksBroken + 1);
+                    int blocksNeeded = (int) task.getConfigValue("amount");
 
-                    if (((int) taskProgress.getProgress()) >= brokenBlocksNeeded) {
+                    int progressBlocks;
+                    if (taskProgress.getProgress() == null) {
+                        progressBlocks = 0;
+                    } else {
+                        progressBlocks = (int) taskProgress.getProgress();
+                    }
+
+                    taskProgress.setProgress(progressBlocks + 1);
+
+                    if (((int) taskProgress.getProgress()) >= blocksNeeded) {
                         taskProgress.setCompleted(true);
                     }
                 }

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/type/FarmingTaskType.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/type/FarmingTaskType.java
@@ -21,7 +21,7 @@ import java.util.List;
 
 public final class FarmingTaskType extends BukkitTaskType {
 
-    public static BukkitQuestsPlugin plugin;
+    private final BukkitQuestsPlugin plugin;
 
     public FarmingTaskType(BukkitQuestsPlugin plugin) {
         super("farming", TaskUtils.TASK_ATTRIBUTION_STRING, "Break a set amount of any crop.");

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/type/FarmingTaskType.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/type/FarmingTaskType.java
@@ -9,7 +9,6 @@ import com.leonardobishop.quests.common.player.questprogressfile.QuestProgress;
 import com.leonardobishop.quests.common.player.questprogressfile.TaskProgress;
 import com.leonardobishop.quests.common.quest.Quest;
 import com.leonardobishop.quests.common.quest.Task;
-import org.bukkit.Bukkit;
 import org.bukkit.block.Block;
 import org.bukkit.block.data.Ageable;
 import org.bukkit.entity.Player;


### PR DESCRIPTION
Closes https://github.com/LMBishop/Quests/issues/363, there are small changes required on task configuration layout wiki page.

Now `farming` and `farmingcertain` task types have optional `mode` option to specify farming mode: `break` or `harvest`. If `mode` is not specified, any mode of farming will count toward the task.
