### PR TITLE
Added admin items give subcommand

### DIFF
--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/command/AdminItemsCommandHandler.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/command/AdminItemsCommandHandler.java
@@ -69,7 +69,7 @@ public class AdminItemsCommandHandler implements CommandHandler {
                 e.printStackTrace();
                 sender.sendMessage(ChatColor.RED + "Couldn't save item. See console for problem.");
             }
-        } else if (args.length >= 5 && args[2].equalsIgnoreCase("give") && sender instanceof Player) {
+        } else if (args.length >= 5 && args[2].equalsIgnoreCase("give")) {
             Player targetPlayer = plugin.getServer().getPlayer(args[3]);
 
             if (targetPlayer == null) {

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/command/AdminItemsCommandHandler.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/command/AdminItemsCommandHandler.java
@@ -35,7 +35,7 @@ public class AdminItemsCommandHandler implements CommandHandler {
             }
             sender.sendMessage(ChatColor.GRAY.toString() + plugin.getQuestItemRegistry().getAllItems().size() + " items imported.");
             sender.sendMessage(ChatColor.DARK_GRAY + "Import a new held item using /q a items import <id>.");
-            sender.sendMessage(ChatColor.DARK_GRAY + "Give a quest item to a player using /q a items give <PlayerName> <id> <amount>.");
+            sender.sendMessage(ChatColor.DARK_GRAY + "Give a quest item to a player using /q a items give <player> <id> <amount>.");
         } else if (args[2].equalsIgnoreCase("import") && sender instanceof Player) {
             Player player = (Player) sender;
             ItemStack held = new ItemStack(player.getItemInHand());


### PR DESCRIPTION
Added "q a items give" sub command.

This feature allows giving a specific amount of a defined quest item to players.
It is useful both for testing purposes when designing quests as well as for giving quest item based rewards to players.

When defining quest items in yaml configs, it is useful to preview the items in-game before adding them to a quest. As such, an admin can use '/q a items give "PlayerName" "QuestItemId" "Amount"' in order to see how the defined item would look in-game.

The same command can also be issued by the CONSOLE as part of a "reward:" block in a quest's config file.

This pull request contains the logic of the command as well as TAB suggestions and example usage when issuing '/q a items' with no other args.