### PR TITLE
Legacy pattern doesn't detect § symbol (causes error)

### DIFF
--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/util/chat/Chat.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/util/chat/Chat.java
@@ -36,7 +36,7 @@ public class Chat {
             questsPlugin.getQuestsLogger().debug("Modern chat is not available, resorting to legacy chat.");
             miniMessageParser = null;
         }
-        legacyPattern = Pattern.compile("&(?:\\d|#|[a-f]|[k-o]|r)");
+        legacyPattern = Pattern.compile("(&|§)(?:\\d|#|[a-f]|[k-o]|r)");
     }
 
     @Contract("null -> null")


### PR DESCRIPTION
Legacy pattern doesn't detect § symbol which causes error: 
```
[Server] ERROR Could not pass event InventoryClickEvent to Quests v3.13.2-82af8a4
[Server] INFO net.kyori.adventure.text.minimessage.internal.parser.ParsingExceptionImpl: Legacy formatting codes have been detected in a MiniMessage string - this is unsupported behaviour. Please refer to the Adventure documentation (https://docs.adventure.kyori.net) for more information.
[Server] INFO §cCancel message.
```

Example that causes this issue:
![image](https://user-images.githubusercontent.com/72739475/216298937-f5f15767-8db9-4433-8ef9-1aed575d1577.png)

ChatColor.RED got translated to §