### PR TITLE
Add config for paginated menu slot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ CHANGELOG_MD
 CHANGELOG_GFM
 UPDATE_MESSAGE
 
+*.classpath
+*.project

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/menu/CategoryQMenu.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/menu/CategoryQMenu.java
@@ -19,13 +19,10 @@ import java.util.List;
  */
 public class CategoryQMenu extends PaginatedQMenu {
 
-    private final BukkitQuestsPlugin plugin;
-
     public CategoryQMenu(BukkitQuestsPlugin plugin, QPlayer owner) {
         super(owner, Chat.legacyColor(plugin.getQuestsConfig().getString("options.guinames.quests-category")),
                 plugin.getQuestsConfig().getBoolean("options.trim-gui-size"), 54, plugin);
 
-        this.plugin = plugin;
         BukkitQuestsConfig config = (BukkitQuestsConfig) plugin.getQuestsConfig();
 
         List<MenuElement> categoryMenuElements = new ArrayList<>();

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/menu/PaginatedQMenu.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/menu/PaginatedQMenu.java
@@ -60,7 +60,7 @@ public abstract class PaginatedQMenu extends QMenu {
         this.maxPage = maxPage;
     }
 
-    public void populate(String customElementsPath, List<MenuElement> menuElementsToFill, MenuElement backMenuElement) {
+    public void populate(String customElementsPath, List<MenuElement> menuElementsToFill, BackMenuElement backMenuElement) {
         Player player = Bukkit.getPlayer(owner.getPlayerUUID());
         if (player == null) {
             return;
@@ -68,7 +68,7 @@ public abstract class PaginatedQMenu extends QMenu {
 
         MenuElement[] staticMenuElements = new MenuElement[pageSize];
         int customStaticElements = 0;
-        MenuElement spacer = new SpacerMenuElement();
+        SpacerMenuElement spacer = new SpacerMenuElement();
 
         // populate custom elements first
         if (customElementsPath != null) {
@@ -100,7 +100,6 @@ public abstract class PaginatedQMenu extends QMenu {
             }
         }
 
-        // TODO: make these page controls configurable
         // if the amount of predicted menu elements is greater than the size of a page, add
         // the page controls as menu elements
         // this won't check if static elements overlap normal ones first but i don't care
@@ -108,21 +107,26 @@ public abstract class PaginatedQMenu extends QMenu {
         BukkitQuestsConfig config = (BukkitQuestsConfig) plugin.getQuestsConfig();
         if ((menuElements.isEmpty() ? 0 : Ints.max(menuElements.keys)) + 1 > maxSize
                 || menuElements.size() + menuElementsToFill.size() + customStaticElements > maxSize) {
-            MenuElement pageNextMenuElement = new PageNextMenuElement(config, this);
-            MenuElement pagePrevMenuElement = new PagePrevMenuElement(config, this);
-            MenuElement pageDescMenuElement = new PageDescMenuElement(config, this);
-            staticMenuElements[45] = backMenuElement == null ? spacer : backMenuElement;
+        	PageNextMenuElement pageNextMenuElement = new PageNextMenuElement(config, this);
+        	PagePrevMenuElement pagePrevMenuElement = new PagePrevMenuElement(config, this);
+        	PageDescMenuElement pageDescMenuElement = new PageDescMenuElement(config, this);
+        	// add manually spacer then let people change item
             staticMenuElements[46] = spacer;
             staticMenuElements[47] = spacer;
-            staticMenuElements[48] = pagePrevMenuElement;
-            staticMenuElements[49] = pageDescMenuElement;
-            staticMenuElements[50] = pageNextMenuElement;
             staticMenuElements[51] = spacer;
             staticMenuElements[52] = spacer;
             staticMenuElements[53] = spacer;
+        	if(backMenuElement != null && backMenuElement.isEnabled())
+        		staticMenuElements[backMenuElement.getSlot()] = backMenuElement == null ? spacer : backMenuElement;
+            if(pagePrevMenuElement.isEnabled())
+            	staticMenuElements[pagePrevMenuElement.getSlot()] = pagePrevMenuElement;
+            if(pageDescMenuElement.isEnabled())
+            	staticMenuElements[pageDescMenuElement.getSlot()] = pageDescMenuElement;
+            if(pageNextMenuElement.isEnabled())
+            	staticMenuElements[pageNextMenuElement.getSlot()] = pageNextMenuElement;
 
             // else find a place for the back button if needed
-        } else if (backMenuElement != null) {
+        } else if (backMenuElement != null && backMenuElement.isEnabled()) {
             int slot = MenuUtils.getHigherOrEqualMultiple(menuElements.size() + menuElementsToFill.size() + customStaticElements, 9);
             staticMenuElements[slot] = backMenuElement;
         }

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/menu/QuestQMenu.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/menu/QuestQMenu.java
@@ -29,7 +29,7 @@ public class QuestQMenu extends PaginatedQMenu {
         BukkitQuestsConfig config = (BukkitQuestsConfig) plugin.getQuestsConfig();
         this.categoryName = categoryName;
 
-        MenuElement backMenuElement = categoryQMenu != null
+        BackMenuElement backMenuElement = categoryQMenu != null
                 ? new BackMenuElement(config, owner.getPlayerUUID(), plugin.getMenuController(), categoryQMenu)
                 : null;
 

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/menu/element/BackMenuElement.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/menu/element/BackMenuElement.java
@@ -36,4 +36,13 @@ public class BackMenuElement extends MenuElement {
         controller.openMenu(player, previousMenu);
         return ClickResult.DO_NOTHING;
     }
+    
+    public int getSlot() {
+    	return config.getInt("gui.back-button.slot", 45);
+    }
+    
+    @Override
+    public boolean isEnabled() {
+    	return config.getBoolean("gui.back-button.enabled", true);
+    }
 }

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/menu/element/MenuElement.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/menu/element/MenuElement.java
@@ -16,4 +16,7 @@ public abstract class MenuElement {
      */
     public abstract ClickResult handleClick(ClickType clickType);
 
+    public boolean isEnabled() {
+    	return true;
+    }
 }

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/menu/element/PageDescMenuElement.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/menu/element/PageDescMenuElement.java
@@ -31,4 +31,13 @@ public class PageDescMenuElement extends MenuElement {
     public ClickResult handleClick(ClickType clickType) {
         return ClickResult.DO_NOTHING;
     }
+    
+    public int getSlot() {
+    	return config.getInt("gui.page-desc.slot", 49);
+    }
+    
+    @Override
+    public boolean isEnabled() {
+    	return config.getBoolean("gui.page-desc.enabled", true);
+    }
 }

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/menu/element/PageNextMenuElement.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/menu/element/PageNextMenuElement.java
@@ -34,4 +34,13 @@ public class PageNextMenuElement extends MenuElement {
         menu.setCurrentPage(menu.getCurrentPage() + 1);
         return ClickResult.REFRESH_PANE;
     }
+    
+    public int getSlot() {
+    	return config.getInt("gui.page-next.slot", 50);
+    }
+    
+    @Override
+    public boolean isEnabled() {
+    	return config.getBoolean("gui.page-next.enabled", true);
+    }
 }

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/menu/element/PagePrevMenuElement.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/menu/element/PagePrevMenuElement.java
@@ -34,4 +34,13 @@ public class PagePrevMenuElement extends MenuElement {
         menu.setCurrentPage(menu.getCurrentPage() - 1);
         return ClickResult.REFRESH_PANE;
     }
+    
+    public int getSlot() {
+    	return config.getInt("gui.page-prev.slot", 48);
+    }
+    
+    @Override
+    public boolean isEnabled() {
+    	return config.getBoolean("gui.page-prev.enabled", true);
+    }
 }

--- a/bukkit/src/main/resources/resources/bukkit/config.yml
+++ b/bukkit/src/main/resources/resources/bukkit/config.yml
@@ -216,21 +216,29 @@ global-macros:
 # -----------------------------------------------------------
 gui:
   back-button:
+    enabled: true
+    slot: 45
     name: "&cReturn"
     lore:
       - "&7Return to the categories menu."
     type: "ARROW"
   page-prev:
+    enabled: true
+    slot: 48
     name: "&7Previous Page"
     lore:
       - "&7Switch the page to page &c{prevpage}."
     type: "FEATHER"
   page-next:
+    enabled: true
+    slot: 50
     name: "&7Next Page"
     lore:
       - "&7Switch the page to page &c{nextpage}."
     type: "FEATHER"
   page-desc:
+    enabled: true
+    slot: 49
     name: "&7Page &c{page}"
     lore:
       - "&7You are currently viewing page &c{page}."


### PR DESCRIPTION
Now, in config there is new lines for `page-desc`, `page-next`, `page-prev`, `back-button`:
```yml
enabled: true
slot: 49
```
It help people to disable or change slot of items.

I also just add some eclipse item in gitignore