### PR TITLE
Add BossBar and ActionBar for tracked quests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ UPDATE_MESSAGE
 
 *.classpath
 *.project
+*/bin/
+*.settings/

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/BukkitQuestsPlugin.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/BukkitQuestsPlugin.java
@@ -3,6 +3,9 @@ package com.leonardobishop.quests.bukkit;
 import com.leonardobishop.quests.bukkit.command.QuestsCommandSwitcher;
 import com.leonardobishop.quests.bukkit.config.BukkitQuestsConfig;
 import com.leonardobishop.quests.bukkit.config.BukkitQuestsLoader;
+import com.leonardobishop.quests.bukkit.hook.bossbar.BossBar;
+import com.leonardobishop.quests.bukkit.hook.bossbar.BossBar_Bukkit;
+import com.leonardobishop.quests.bukkit.hook.bossbar.BossBar_Nothing;
 import com.leonardobishop.quests.bukkit.hook.coreprotect.AbstractCoreProtectHook;
 import com.leonardobishop.quests.bukkit.hook.coreprotect.CoreProtectHook;
 import com.leonardobishop.quests.bukkit.hook.essentials.AbstractEssentialsHook;
@@ -99,6 +102,7 @@ public class BukkitQuestsPlugin extends JavaPlugin implements Quests {
     private AbstractPlayerBlockTrackerHook playerBlockTrackerHook;
     private ItemGetter itemGetter;
     private Title titleHandle;
+    private BossBar bossBarHandle;
     private VersionSpecificHandler versionSpecificHandler;
 
     private LogHistory logHistory;
@@ -216,6 +220,11 @@ public class BukkitQuestsPlugin extends JavaPlugin implements Quests {
         } else {
             titleHandle = new Title_Bukkit();
         }
+        // (bossbar)
+        if(version <= 8)
+        	bossBarHandle = new BossBar_Nothing();
+        else
+        	bossBarHandle = new BossBar_Bukkit(this);
         // (itemstacks)
         if (version <= 12) {
             itemGetter = new ItemGetter_Late_1_8();
@@ -619,6 +628,10 @@ public class BukkitQuestsPlugin extends JavaPlugin implements Quests {
     public Title getTitleHandle() {
         return titleHandle;
     }
+    
+    public BossBar getBossBarHandle() {
+		return bossBarHandle;
+	}
 
     public VersionSpecificHandler getVersionSpecificHandler() {
         return versionSpecificHandler;

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/command/AdminCommandSwitcher.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/command/AdminCommandSwitcher.java
@@ -7,11 +7,8 @@ import org.jetbrains.annotations.Nullable;
 
 public class AdminCommandSwitcher extends CommandSwitcher {
 
-    private final BukkitQuestsPlugin plugin;
-
     public AdminCommandSwitcher(BukkitQuestsPlugin plugin) {
         super(1);
-        this.plugin = plugin;
 
         super.subcommands.put("opengui", new AdminOpenguiCommandSwitcher(plugin));
         super.subcommands.put("moddata", new AdminModdataCommandSwitcher(plugin));

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/hook/actionbar/ActionBar.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/hook/actionbar/ActionBar.java
@@ -1,0 +1,9 @@
+package com.leonardobishop.quests.bukkit.hook.actionbar;
+
+import org.bukkit.entity.Player;
+
+public interface ActionBar {
+
+	void sendActionBar(Player p, String line);
+
+}

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/hook/actionbar/ActionBar_Bukkit.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/hook/actionbar/ActionBar_Bukkit.java
@@ -1,0 +1,15 @@
+package com.leonardobishop.quests.bukkit.hook.actionbar;
+
+import org.bukkit.entity.Player;
+
+import net.md_5.bungee.api.ChatMessageType;
+import net.md_5.bungee.api.chat.TextComponent;
+
+public class ActionBar_Bukkit implements ActionBar {
+
+	@SuppressWarnings("deprecation")
+	@Override
+	public void sendActionBar(Player p, String line) {
+		p.spigot().sendMessage(ChatMessageType.ACTION_BAR, new TextComponent(line));
+	}
+}

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/hook/actionbar/ActionBar_Nothing.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/hook/actionbar/ActionBar_Nothing.java
@@ -1,0 +1,12 @@
+package com.leonardobishop.quests.bukkit.hook.actionbar;
+
+import org.bukkit.entity.Player;
+
+public class ActionBar_Nothing implements ActionBar {
+
+	@Override
+	public void sendActionBar(Player p, String line) {
+		// version as 1.9 and under
+	}
+
+}

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/hook/bossbar/BossBar.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/hook/bossbar/BossBar.java
@@ -1,0 +1,11 @@
+package com.leonardobishop.quests.bukkit.hook.bossbar;
+
+import org.bukkit.entity.Player;
+
+public interface BossBar {
+
+	void sendBossBar(Player p, String questKey, String title, int time);
+
+	void sendBossBar(Player p, String questKey, String title, int progress, int time);
+	
+}

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/hook/bossbar/BossBar_Bukkit.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/hook/bossbar/BossBar_Bukkit.java
@@ -57,7 +57,7 @@ public class BossBar_Bukkit implements BossBar {
 			bar.setTitle(title);
 		}
 		players.put(spaceKey, System.currentTimeMillis() + time * 1000);
-		bar.setProgress(((double) percent) / 100);
+		bar.setProgress(percent > 100 ? 1 : ((double) percent) / 100);
 		bar.addPlayer(p); // be sure it see it
 	}
 

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/hook/bossbar/BossBar_Bukkit.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/hook/bossbar/BossBar_Bukkit.java
@@ -57,7 +57,8 @@ public class BossBar_Bukkit implements BossBar {
 			bar.setTitle(title);
 		}
 		players.put(spaceKey, System.currentTimeMillis() + time * 1000);
-		bar.setProgress(percent > 100 ? 1 : ((double) percent) / 100);
+		double progress = ((double) percent) / 100;
+		bar.setProgress(progress < 0 ? 0 : (progress > 1 ? 1 : progress));
 		bar.addPlayer(p); // be sure it see it
 	}
 

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/hook/bossbar/BossBar_Bukkit.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/hook/bossbar/BossBar_Bukkit.java
@@ -1,0 +1,67 @@
+package com.leonardobishop.quests.bukkit.hook.bossbar;
+
+import java.util.HashMap;
+import java.util.Map.Entry;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.bukkit.Bukkit;
+import org.bukkit.NamespacedKey;
+import org.bukkit.boss.BarColor;
+import org.bukkit.boss.BarStyle;
+import org.bukkit.entity.Player;
+
+import com.leonardobishop.quests.bukkit.BukkitQuestsPlugin;
+
+public class BossBar_Bukkit implements BossBar {
+
+	private BukkitQuestsPlugin plugin;
+	private final ConcurrentHashMap<NamespacedKey, Long> players = new ConcurrentHashMap<>();
+
+	public BossBar_Bukkit(BukkitQuestsPlugin plugin) {
+		this.plugin = plugin;
+		plugin.getScheduler().runTaskTimer(() -> {
+			for (Entry<NamespacedKey, Long> entry : new HashMap<>(players).entrySet()) {
+				if (entry.getValue() < System.currentTimeMillis()) {
+					NamespacedKey key = entry.getKey();
+					players.remove(key);
+					org.bukkit.boss.BossBar oldBar = Bukkit.getBossBar(key);
+					if(oldBar != null) { // if exist
+						oldBar.removeAll(); // remove all players on it
+						Bukkit.removeBossBar(key); // remove it
+					}
+				}
+			}
+		}, 20, 20);
+	}
+
+	@Override
+	public void sendBossBar(Player p, String questKey, String title, int time) {
+		NamespacedKey spaceKey = getKeyFor(p, questKey);
+		org.bukkit.boss.BossBar bar = Bukkit.getBossBar(spaceKey);
+		if (bar == null) {// if none exist
+			bar = Bukkit.createBossBar(spaceKey, title, BarColor.BLUE, BarStyle.SOLID);
+		} else {
+			bar.setTitle(title);
+		}
+		players.put(spaceKey, System.currentTimeMillis() + time * 1000);
+		bar.addPlayer(p); // be sure it see it
+	}
+
+	@Override
+	public void sendBossBar(Player p, String questKey, String title, int percent, int time) {
+		NamespacedKey spaceKey = getKeyFor(p, questKey);
+		org.bukkit.boss.BossBar bar = Bukkit.getBossBar(spaceKey);
+		if (bar == null) {// if none exist
+			bar = Bukkit.createBossBar(spaceKey, title, BarColor.BLUE, BarStyle.SOLID);
+		} else {
+			bar.setTitle(title);
+		}
+		players.put(spaceKey, System.currentTimeMillis() + time * 1000);
+		bar.setProgress(((double) percent) / 100);
+		bar.addPlayer(p); // be sure it see it
+	}
+
+	private NamespacedKey getKeyFor(Player p, String questKey) {
+		return new NamespacedKey(plugin, "bossbar_" + p.getName().toLowerCase() + "_" + questKey.toLowerCase().replace(" ", ""));
+	}
+}

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/hook/bossbar/BossBar_Nothing.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/hook/bossbar/BossBar_Nothing.java
@@ -1,0 +1,17 @@
+package com.leonardobishop.quests.bukkit.hook.bossbar;
+
+import org.bukkit.entity.Player;
+
+public class BossBar_Nothing implements BossBar {
+
+	@Override
+	public void sendBossBar(Player p, String questKey, String title, int time) {
+		// old versions as 1.8
+	}
+
+	@Override
+	public void sendBossBar(Player p, String questKey, String title, int progress, int time) {
+		// old versions as 1.8
+	}
+
+}

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/menu/itemstack/QItemStack.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/menu/itemstack/QItemStack.java
@@ -7,6 +7,7 @@ import com.leonardobishop.quests.bukkit.util.chat.Chat;
 import com.leonardobishop.quests.common.player.QPlayer;
 import com.leonardobishop.quests.common.player.questprogressfile.QuestProgress;
 import com.leonardobishop.quests.common.player.questprogressfile.QuestProgressFile;
+import com.leonardobishop.quests.common.player.questprogressfile.TaskProgress;
 import com.leonardobishop.quests.common.quest.Quest;
 import org.bukkit.Bukkit;
 import org.bukkit.enchantments.Enchantment;
@@ -128,6 +129,39 @@ public class QItemStack {
         ism.setLore(formattedLore);
         is.setItemMeta(ism);
         return is;
+    }
+
+    public static String processPlaceholders(String s, TaskProgress taskProgress) {
+        Matcher m = Pattern.compile("\\{([^}]+)}").matcher(s);
+        while (m.find()) {
+            String[] parts = m.group(1).split(":");
+            if (parts.length > 1) {
+                if (taskProgress == null) {
+                    continue;
+                }
+                if (parts[1].equals("progress")) {
+                    Object progress = taskProgress.getProgress();
+                    String str;
+                    if (progress instanceof Float || progress instanceof Double || progress instanceof BigDecimal) {
+                        str = String.format("%.2f", progress);
+                    } else {
+                        str = String.valueOf(progress);
+                    }
+
+                    s = s.replace("{" + m.group(1) + "}", (progress == null ? String.valueOf(0) : str));
+                }
+                if (parts[1].equals("complete")) {
+                    String str;
+                    if (taskProgress.isCompleted()) {
+                        str = Chat.legacyColor(Messages.UI_PLACEHOLDERS_TRUE.getMessageLegacyColor());
+                    } else {
+                        str = Chat.legacyColor(Messages.UI_PLACEHOLDERS_FALSE.getMessageLegacyColor());
+                    }
+                    s = s.replace("{" + m.group(1) + "}", str);
+                }
+            }
+        }
+        return s;
     }
 
     public static String processPlaceholders(String s, QuestProgress questProgress) {

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/questcompleter/BukkitQuestCompleter.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/questcompleter/BukkitQuestCompleter.java
@@ -22,7 +22,6 @@ public class BukkitQuestCompleter implements QuestCompleter, Runnable {
     private final LinkedList<QuestProgressFile> fullCheckQueue = new LinkedList<>();
     private final LinkedList<UUID> expiredCheckQueue = new LinkedList<>();
     private final BukkitQuestsPlugin plugin;
-    private int expiredQuestsCheckCountdown;
 
     public BukkitQuestCompleter(BukkitQuestsPlugin plugin) {
         this.plugin = plugin;

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/type/BlockshearingTaskType.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/type/BlockshearingTaskType.java
@@ -61,6 +61,7 @@ public final class BlockshearingTaskType extends BukkitTaskType {
                 super.debug("Marking task as complete", quest.getId(), task.getId(), player.getUniqueId());
                 taskProgress.setCompleted(true);
             }
+            TaskUtils.sendTrackAdvancement(player, quest, taskProgress);
         }
     }
 }

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/type/BreedingTaskType.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/type/BreedingTaskType.java
@@ -111,6 +111,7 @@ public final class BreedingTaskType extends BukkitTaskType {
                 super.debug("Marking task as complete", quest.getId(), task.getId(), player.getUniqueId());
                 taskProgress.setCompleted(true);
             }
+            TaskUtils.sendTrackAdvancement(player, quest, taskProgress);
         }
     }
 }

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/type/BrewingTaskType.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/type/BrewingTaskType.java
@@ -114,8 +114,7 @@ public final class BrewingTaskType extends BukkitTaskType {
                 }
             }
 
-            int progress = TaskUtils.getIntegerTaskProgress(taskProgress);
-            taskProgress.setProgress(progress + eventAmount);
+            int progress = TaskUtils.incrementIntegerTaskProgress(taskProgress, eventAmount);
             super.debug("Updating task progress (now " + (progress + eventAmount) + ")", quest.getId(), task.getId(), player.getUniqueId());
 
             int amount = (int) task.getConfigValue("amount");
@@ -125,6 +124,7 @@ public final class BrewingTaskType extends BukkitTaskType {
                 taskProgress.setProgress(amount);
                 taskProgress.setCompleted(true);
             }
+            TaskUtils.sendTrackAdvancement(player, quest, taskProgress);
         }
     }
 }

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/type/BucketInteractionTaskType.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/type/BucketInteractionTaskType.java
@@ -56,6 +56,7 @@ public abstract class BucketInteractionTaskType extends BukkitTaskType {
                 super.debug("Marking task as complete", quest.getId(), task.getId(), player.getUniqueId());
                 taskProgress.setCompleted(true);
             }
+            TaskUtils.sendTrackAdvancement(player, quest, taskProgress);
         }
     }
 

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/type/BuildingTaskType.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/type/BuildingTaskType.java
@@ -65,6 +65,7 @@ public final class BuildingTaskType extends BukkitTaskType {
                 super.debug("Marking task as complete", quest.getId(), task.getId(), player.getUniqueId());
                 taskProgress.setCompleted(true);
             }
+            TaskUtils.sendTrackAdvancement(player, quest, taskProgress);
         }
     }
 

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/type/ConsumeTaskType.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/type/ConsumeTaskType.java
@@ -82,6 +82,7 @@ public final class ConsumeTaskType extends BukkitTaskType {
                 super.debug("Marking task as complete", quest.getId(), task.getId(), player.getUniqueId());
                 taskProgress.setCompleted(true);
             }
+            TaskUtils.sendTrackAdvancement(player, quest, taskProgress);
         }
     }
 }

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/type/CraftingTaskType.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/type/CraftingTaskType.java
@@ -102,8 +102,7 @@ public final class CraftingTaskType extends BukkitTaskType {
                 continue;
             }
 
-            int progress = TaskUtils.getIntegerTaskProgress(taskProgress);
-            taskProgress.setProgress(progress + eventAmount);
+            int progress = TaskUtils.incrementIntegerTaskProgress(taskProgress, eventAmount);
             super.debug("Updating task progress (now " + (progress + eventAmount) + ")", quest.getId(), task.getId(), player.getUniqueId());
 
             int amount = (int) task.getConfigValue("amount");
@@ -113,6 +112,7 @@ public final class CraftingTaskType extends BukkitTaskType {
                 taskProgress.setProgress(amount);
                 taskProgress.setCompleted(true);
             }
+            TaskUtils.sendTrackAdvancement(player, quest, taskProgress);
         }
     }
 

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/type/DealDamageTaskType.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/type/DealDamageTaskType.java
@@ -70,6 +70,7 @@ public final class DealDamageTaskType extends BukkitTaskType {
                 super.debug("Marking task as complete", quest.getId(), task.getId(), player.getUniqueId());
                 taskProgress.setCompleted(true);
             }
+            TaskUtils.sendTrackAdvancement(player, quest, taskProgress);
         }
     }
 }

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/type/EnchantingTaskType.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/type/EnchantingTaskType.java
@@ -109,6 +109,7 @@ public final class EnchantingTaskType extends BukkitTaskType {
                 super.debug("Marking task as complete", quest.getId(), task.getId(), player.getUniqueId());
                 taskProgress.setCompleted(true);
             }
+            TaskUtils.sendTrackAdvancement(player, quest, taskProgress);
         }
     }
 }

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/type/ExpEarnTaskType.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/type/ExpEarnTaskType.java
@@ -46,16 +46,15 @@ public final class ExpEarnTaskType extends BukkitTaskType {
 
             int expNeeded = (int) task.getConfigValue("amount");
 
-            int progress = TaskUtils.getIntegerTaskProgress(taskProgress);
-            int newProgress = progress + amountEarned;
-            taskProgress.setProgress(newProgress);
-            super.debug("Updating task progress (now " + (newProgress) + ")", quest.getId(), task.getId(), player.getUniqueId());
+            int progress = TaskUtils.incrementIntegerTaskProgress(taskProgress, amountEarned);
+            super.debug("Updating task progress (now " + (progress) + ")", quest.getId(), task.getId(), player.getUniqueId());
 
-            if (newProgress >= expNeeded) {
+            if (progress >= expNeeded) {
                 super.debug("Marking task as complete", quest.getId(), task.getId(), player.getUniqueId());
-                taskProgress.setProgress(newProgress);
+                taskProgress.setProgress(expNeeded);
                 taskProgress.setCompleted(true);
             }
+            TaskUtils.sendTrackAdvancement(player, quest, taskProgress);
         }
     }
 }

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/type/FarmingTaskType.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/type/FarmingTaskType.java
@@ -89,6 +89,7 @@ public final class FarmingTaskType extends BukkitTaskType {
                 super.debug("Marking task as complete", quest.getId(), task.getId(), player.getUniqueId());
                 taskProgress.setCompleted(true);
             }
+            TaskUtils.sendTrackAdvancement(player, quest, taskProgress);
         }
     }
 }

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/type/FishingTaskType.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/type/FishingTaskType.java
@@ -95,6 +95,7 @@ public final class FishingTaskType extends BukkitTaskType {
                 super.debug("Marking task as complete", quest.getId(), task.getId(), player.getUniqueId());
                 taskProgress.setCompleted(true);
             }
+            TaskUtils.sendTrackAdvancement(player, quest, taskProgress);
         }
     }
 }

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/type/InteractTaskType.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/type/InteractTaskType.java
@@ -105,6 +105,7 @@ public final class InteractTaskType extends BukkitTaskType {
                 super.debug("Marking task as complete", quest.getId(), task.getId(), player.getUniqueId());
                 taskProgress.setCompleted(true);
             }
+            TaskUtils.sendTrackAdvancement(player, quest, taskProgress);
         }
     }
 }

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/type/InventoryTaskType.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/type/InventoryTaskType.java
@@ -164,6 +164,7 @@ public final class InventoryTaskType extends BukkitTaskType {
                     }
                 }
             }
+            TaskUtils.sendTrackAdvancement(player, quest, taskProgress);
         }
     }
 

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/type/MilkingTaskType.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/type/MilkingTaskType.java
@@ -58,6 +58,7 @@ public final class MilkingTaskType extends BukkitTaskType {
                 super.debug("Marking task as complete", quest.getId(), task.getId(), player.getUniqueId());
                 taskProgress.setCompleted(true);
             }
+            TaskUtils.sendTrackAdvancement(player, quest, taskProgress);
         }
     }
 

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/type/MiningTaskType.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/type/MiningTaskType.java
@@ -104,6 +104,7 @@ public final class MiningTaskType extends BukkitTaskType {
                     super.debug("Marking task as complete", quest.getId(), task.getId(), player.getUniqueId());
                     taskProgress.setCompleted(true);
                 }
+                TaskUtils.sendTrackAdvancement(player, quest, taskProgress);
             };
 
             boolean coreProtectEnabled = TaskUtils.getConfigBoolean(task, "check-coreprotect");

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/type/MobkillingTaskType.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/type/MobkillingTaskType.java
@@ -130,6 +130,7 @@ public final class MobkillingTaskType extends BukkitTaskType {
                 super.debug("Marking task as complete", quest.getId(), task.getId(), player.getUniqueId());
                 taskProgress.setCompleted(true);
             }
+            TaskUtils.sendTrackAdvancement(player, quest, taskProgress);
         }
     }
 }

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/type/PlayerkillingTaskType.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/type/PlayerkillingTaskType.java
@@ -57,6 +57,7 @@ public final class PlayerkillingTaskType extends BukkitTaskType {
                 super.debug("Marking task as complete", quest.getId(), task.getId(), killer.getUniqueId());
                 taskProgress.setCompleted(true);
             }
+            TaskUtils.sendTrackAdvancement(killer, quest, taskProgress);
         }
     }
 

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/type/PlaytimeTaskType.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/type/PlaytimeTaskType.java
@@ -66,6 +66,7 @@ public final class PlaytimeTaskType extends BukkitTaskType {
                                 PlaytimeTaskType.super.debug("Marking task as complete", quest.getId(), task.getId(), player.getUniqueId());
                                 taskProgress.setCompleted(true);
                             }
+                            TaskUtils.sendTrackAdvancement(player, quest, taskProgress);
                         }
                     }
                 }

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/type/ReplenishingTaskType.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/type/ReplenishingTaskType.java
@@ -81,6 +81,7 @@ public final class ReplenishingTaskType extends BukkitTaskType {
                 super.debug("Marking task as complete", quest.getId(), task.getId(), player.getUniqueId());
                 taskProgress.setCompleted(true);
             }
+            TaskUtils.sendTrackAdvancement(player, quest, taskProgress);
         }
     }
 }

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/type/ShearingTaskType.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/type/ShearingTaskType.java
@@ -69,6 +69,7 @@ public final class ShearingTaskType extends BukkitTaskType {
                 super.debug("Marking task as complete", quest.getId(), task.getId(), player.getUniqueId());
                 taskProgress.setCompleted(true);
             }
+            TaskUtils.sendTrackAdvancement(player, quest, taskProgress);
         }
     }
 }

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/type/SmeltingTaskType.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/type/SmeltingTaskType.java
@@ -120,8 +120,7 @@ public final class SmeltingTaskType extends BukkitTaskType {
                 }
             }
 
-            int progress = TaskUtils.getIntegerTaskProgress(taskProgress);
-            taskProgress.setProgress(progress + eventAmount);
+            int progress = TaskUtils.incrementIntegerTaskProgress(taskProgress, eventAmount);
             super.debug("Updating task progress (now " + (progress + eventAmount) + ")", quest.getId(), task.getId(), player.getUniqueId());
 
             int amount = (int) task.getConfigValue("amount");
@@ -131,6 +130,7 @@ public final class SmeltingTaskType extends BukkitTaskType {
                 taskProgress.setProgress(amount);
                 taskProgress.setCompleted(true);
             }
+            TaskUtils.sendTrackAdvancement(player, quest, taskProgress);
         }
     }
 

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/type/SmithingTaskType.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/type/SmithingTaskType.java
@@ -93,8 +93,7 @@ public final class SmithingTaskType extends BukkitTaskType {
                 continue;
             }
 
-            int progress = TaskUtils.getIntegerTaskProgress(taskProgress);
-            taskProgress.setProgress(progress + eventAmount);
+            int progress = TaskUtils.incrementIntegerTaskProgress(taskProgress, eventAmount);
             super.debug("Updating task progress (now " + (progress + eventAmount) + ")", quest.getId(), task.getId(), player.getUniqueId());
 
             int amount = (int) task.getConfigValue("amount");
@@ -104,6 +103,7 @@ public final class SmithingTaskType extends BukkitTaskType {
                 taskProgress.setProgress(amount);
                 taskProgress.setCompleted(true);
             }
+            TaskUtils.sendTrackAdvancement(player, quest, taskProgress);
         }
     }
 }

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/type/TamingTaskType.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/type/TamingTaskType.java
@@ -67,6 +67,7 @@ public final class TamingTaskType extends BukkitTaskType {
                 super.debug("Marking task as complete", quest.getId(), task.getId(), player.getUniqueId());
                 taskProgress.setCompleted(true);
             }
+            TaskUtils.sendTrackAdvancement(player, quest, taskProgress);
         }
     }
 }

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/type/WalkingTaskType.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/type/WalkingTaskType.java
@@ -106,6 +106,7 @@ public final class WalkingTaskType extends BukkitTaskType {
                 super.debug("Marking task as complete", quest.getId(), task.getId(), player.getUniqueId());
                 taskProgress.setCompleted(true);
             }
+            TaskUtils.sendTrackAdvancement(player, quest, taskProgress);
         }
     }
 

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/type/dependent/ASkyBlockLevelTaskType.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/type/dependent/ASkyBlockLevelTaskType.java
@@ -51,6 +51,7 @@ public final class ASkyBlockLevelTaskType extends BukkitTaskType {
                 taskProgress.setProgress(islandLevelNeeded);
                 taskProgress.setCompleted(true);
             }
+            TaskUtils.sendTrackAdvancement(player, quest, taskProgress);
         }
     }
 }

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/type/dependent/BentoBoxLevelTaskType.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/type/dependent/BentoBoxLevelTaskType.java
@@ -72,6 +72,7 @@ public final class BentoBoxLevelTaskType extends BukkitTaskType {
                         taskProgress.setProgress(newLevel);
                         taskProgress.setCompleted(true);
                     }
+                    TaskUtils.sendTrackAdvancement(player, quest, taskProgress);
                 }
             }
         }

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/type/dependent/CitizensDeliverTaskType.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/type/dependent/CitizensDeliverTaskType.java
@@ -152,6 +152,7 @@ public final class CitizensDeliverTaskType extends BukkitTaskType {
                     }
                 }
             }
+            TaskUtils.sendTrackAdvancement(player, quest, taskProgress);
         }
     }
 

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/type/dependent/EcoBossesKillingTaskType.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/type/dependent/EcoBossesKillingTaskType.java
@@ -57,6 +57,7 @@ public final class EcoBossesKillingTaskType extends BukkitTaskType {
                 super.debug("Marking task as complete", quest.getId(), task.getId(), killer.getUniqueId());
                 taskProgress.setCompleted(true);
             }
+            TaskUtils.sendTrackAdvancement(killer, quest, taskProgress);
         }
     }
 

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/type/dependent/EssentialsBalanceTaskType.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/type/dependent/EssentialsBalanceTaskType.java
@@ -95,6 +95,7 @@ public final class EssentialsBalanceTaskType extends BukkitTaskType {
                 super.debug("Marking task as complete", quest.getId(), task.getId(), player.getUniqueId());
                 taskProgress.setCompleted(true);
             }
+            TaskUtils.sendTrackAdvancement(player, quest, taskProgress);
         }
     }
 

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/type/dependent/EssentialsMoneyEarnTaskType.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/type/dependent/EssentialsMoneyEarnTaskType.java
@@ -69,6 +69,7 @@ public final class EssentialsMoneyEarnTaskType extends BukkitTaskType {
                 super.debug("Marking task as complete", quest.getId(), task.getId(), player.getUniqueId());
                 taskProgress.setCompleted(true);
             }
+            TaskUtils.sendTrackAdvancement(player, quest, taskProgress);
         }
     }
 

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/type/dependent/FabledSkyblockLevelTaskType.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/type/dependent/FabledSkyblockLevelTaskType.java
@@ -64,6 +64,7 @@ public final class FabledSkyblockLevelTaskType extends BukkitTaskType {
                     taskProgress.setProgress(islandLevelNeeded);
                     taskProgress.setCompleted(true);
                 }
+                TaskUtils.sendTrackAdvancement(player, quest, taskProgress);
             }
         }
     }

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/type/dependent/IridiumSkyblockValueTaskType.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/type/dependent/IridiumSkyblockValueTaskType.java
@@ -67,6 +67,7 @@ public final class IridiumSkyblockValueTaskType extends BukkitTaskType {
                     taskProgress.setProgress(islandValueNeeded);
                     taskProgress.setCompleted(true);
                 }
+                TaskUtils.sendTrackAdvancement(player, quest, taskProgress);
             }
         }
 

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/type/dependent/MythicMobsKillingTaskType.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/type/dependent/MythicMobsKillingTaskType.java
@@ -128,6 +128,7 @@ public final class MythicMobsKillingTaskType extends BukkitTaskType {
                 super.debug("Marking task as complete", quest.getId(), task.getId(), player.getUniqueId());
                 taskProgress.setCompleted(true);
             }
+            TaskUtils.sendTrackAdvancement(player, quest, taskProgress);
         }
     }
 

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/type/dependent/NuVotifierVoteTaskType.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/type/dependent/NuVotifierVoteTaskType.java
@@ -55,6 +55,7 @@ public final class NuVotifierVoteTaskType extends BukkitTaskType {
                 super.debug("Marking task as complete", quest.getId(), task.getId(), player.getUniqueId());
                 taskProgress.setCompleted(true);
             }
+            TaskUtils.sendTrackAdvancement(player, quest, taskProgress);
         }
     }
 

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/type/dependent/PlayerPointsEarnTaskType.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/type/dependent/PlayerPointsEarnTaskType.java
@@ -61,6 +61,7 @@ public final class PlayerPointsEarnTaskType extends BukkitTaskType {
                 taskProgress.setProgress(amount);
                 taskProgress.setCompleted(true);
             }
+            TaskUtils.sendTrackAdvancement(player, quest, taskProgress);
         }
     }
 }

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/type/dependent/ShopGUIPlusInteractionTaskType.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/type/dependent/ShopGUIPlusInteractionTaskType.java
@@ -121,6 +121,7 @@ public abstract class ShopGUIPlusInteractionTaskType extends BukkitTaskType {
                 taskProgress.setProgress(amountNeeded);
                 taskProgress.setCompleted(true);
             }
+            TaskUtils.sendTrackAdvancement(player, quest, taskProgress);
         }
     }
 }

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/type/dependent/SuperiorSkyblockLevelType.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/type/dependent/SuperiorSkyblockLevelType.java
@@ -59,6 +59,7 @@ public final class SuperiorSkyblockLevelType extends BukkitTaskType {
                     super.debug("Marking task as complete", quest.getId(), task.getId(), player.getUniqueId());
                     taskProgress.setCompleted(true);
                 }
+                TaskUtils.sendTrackAdvancement(player, quest, taskProgress);
             }
         }
     }

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/type/dependent/SuperiorSkyblockWorthType.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/type/dependent/SuperiorSkyblockWorthType.java
@@ -59,6 +59,7 @@ public final class SuperiorSkyblockWorthType extends BukkitTaskType {
                     super.debug("Marking task as complete", quest.getId(), task.getId(), player.getUniqueId());
                     taskProgress.setCompleted(true);
                 }
+                TaskUtils.sendTrackAdvancement(player, quest, taskProgress);
             }
         }
     }

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/type/dependent/VotingPluginVoteType.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/type/dependent/VotingPluginVoteType.java
@@ -55,6 +55,7 @@ public final class VotingPluginVoteType extends BukkitTaskType {
                 super.debug("Marking task as complete", quest.getId(), task.getId(), player.getUniqueId());
                 taskProgress.setCompleted(true);
             }
+            TaskUtils.sendTrackAdvancement(player, quest, taskProgress);
         }
     }
 

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/type/dependent/uSkyBlockLevelTaskType.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/type/dependent/uSkyBlockLevelTaskType.java
@@ -50,6 +50,7 @@ public final class uSkyBlockLevelTaskType extends BukkitTaskType {
                 taskProgress.setProgress(islandLevelNeeded);
                 taskProgress.setCompleted(true);
             }
+            TaskUtils.sendTrackAdvancement(player, quest, taskProgress);
         }
     }
 

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/util/TaskUtils.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/util/TaskUtils.java
@@ -1,21 +1,5 @@
 package com.leonardobishop.quests.bukkit.util;
 
-import com.leonardobishop.quests.bukkit.BukkitQuestsPlugin;
-import com.leonardobishop.quests.bukkit.item.ParsedQuestItem;
-import com.leonardobishop.quests.bukkit.item.QuestItem;
-import com.leonardobishop.quests.bukkit.menu.itemstack.QItemStack;
-import com.leonardobishop.quests.bukkit.tasktype.BukkitTaskType;
-import com.leonardobishop.quests.bukkit.util.chat.Chat;
-import com.leonardobishop.quests.bukkit.util.constraint.TaskConstraint;
-import com.leonardobishop.quests.bukkit.util.constraint.TaskConstraintSet;
-import com.leonardobishop.quests.common.config.ConfigProblem;
-import com.leonardobishop.quests.common.config.ConfigProblemDescriptions;
-import com.leonardobishop.quests.common.player.QPlayer;
-import com.leonardobishop.quests.common.player.questprogressfile.QuestProgress;
-import com.leonardobishop.quests.common.player.questprogressfile.TaskProgress;
-import com.leonardobishop.quests.common.quest.Quest;
-import com.leonardobishop.quests.common.quest.Task;
-import com.leonardobishop.quests.common.tasktype.TaskType;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -33,6 +17,23 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.material.Colorable;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+
+import com.leonardobishop.quests.bukkit.BukkitQuestsPlugin;
+import com.leonardobishop.quests.bukkit.item.ParsedQuestItem;
+import com.leonardobishop.quests.bukkit.item.QuestItem;
+import com.leonardobishop.quests.bukkit.menu.itemstack.QItemStack;
+import com.leonardobishop.quests.bukkit.tasktype.BukkitTaskType;
+import com.leonardobishop.quests.bukkit.util.chat.Chat;
+import com.leonardobishop.quests.bukkit.util.constraint.TaskConstraint;
+import com.leonardobishop.quests.bukkit.util.constraint.TaskConstraintSet;
+import com.leonardobishop.quests.common.config.ConfigProblem;
+import com.leonardobishop.quests.common.config.ConfigProblemDescriptions;
+import com.leonardobishop.quests.common.player.QPlayer;
+import com.leonardobishop.quests.common.player.questprogressfile.QuestProgress;
+import com.leonardobishop.quests.common.player.questprogressfile.TaskProgress;
+import com.leonardobishop.quests.common.quest.Quest;
+import com.leonardobishop.quests.common.quest.Task;
+import com.leonardobishop.quests.common.tasktype.TaskType;
 
 @SuppressWarnings("deprecation")
 public class TaskUtils {

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/util/TaskUtils.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/util/TaskUtils.java
@@ -160,7 +160,9 @@ public class TaskUtils {
         }
         int progressAmount = getIntegerTaskProgress(progress);
         if(progressAmount > 0) { // if has value
-        	progressAmount = (progressAmount * 100) / (int) q.getTaskById(progress.getTaskId()).getConfigValue("amount"); // convert into percent
+        	Object amount = q.getTaskById(progress.getTaskId()).getConfigValue("amount");
+        	if(amount != null && amount instanceof Integer)
+        		progressAmount = (progressAmount * 100) / (int) amount; // convert into percent
         }
     	if((plugin.getConfig().getBoolean("options.bossbar.complete", true) && progress.isCompleted()) || plugin.getConfig().getBoolean("options.bossbar.progress", true)) {
     		if(progressAmount > 0)

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/util/TaskUtils.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/util/TaskUtils.java
@@ -163,12 +163,17 @@ public class TaskUtils {
         	Object amount = q.getTaskById(progress.getTaskId()).getConfigValue("amount");
         	if(amount != null && amount instanceof Integer)
         		progressAmount = (progressAmount * 100) / (int) amount; // convert into percent
+        	else
+        		progressAmount = 0; // can't find max value
         }
     	if((plugin.getConfig().getBoolean("options.bossbar.complete", true) && progress.isCompleted()) || plugin.getConfig().getBoolean("options.bossbar.progress", true)) {
     		if(progressAmount > 0)
     			plugin.getBossBarHandle().sendBossBar(player, q.getId(), title, progressAmount, plugin.getConfig().getInt("options.bossbar.time", 10));
     		else
     			plugin.getBossBarHandle().sendBossBar(player, q.getId(), title, plugin.getConfig().getInt("options.bossbar.time", 10));
+    	}
+    	if((plugin.getConfig().getBoolean("options.actionbar.complete", true) && progress.isCompleted()) || plugin.getConfig().getBoolean("options.actionbar.progress", true)) {
+    		plugin.getActionBarHandle().sendActionBar(player, title);
     	}
     }
 

--- a/bukkit/src/main/resources/resources/bukkit/config.yml
+++ b/bukkit/src/main/resources/resources/bukkit/config.yml
@@ -42,6 +42,10 @@ options:
     complete: true
     # Time in seconds of bossbar showed
     time: 10
+  # Enable/disable ActionBar
+  actionbar:
+    progress: true
+    complete: true
   # Allow players to have multiple active quests.
   # You can set the default number of quests using the 'default' rank below.
   # To grant different quest limits to different people, you can define a 'quest-rank'

--- a/bukkit/src/main/resources/resources/bukkit/config.yml
+++ b/bukkit/src/main/resources/resources/bukkit/config.yml
@@ -36,6 +36,12 @@ options:
   trim-gui-size: true
   # Enable/disable titles
   titles-enabled: true
+  # Enable/disable BossBars
+  bossbar:
+    progress: true
+    complete: true
+    # Time in seconds of bossbar showed
+    time: 10
   # Allow players to have multiple active quests.
   # You can set the default number of quests using the 'default' rank below.
   # To grant different quest limits to different people, you can define a 'quest-rank'

--- a/bukkit/src/main/resources/resources/bukkit/config.yml
+++ b/bukkit/src/main/resources/resources/bukkit/config.yml
@@ -38,14 +38,14 @@ options:
   titles-enabled: true
   # Enable/disable BossBars
   bossbar:
-    progress: true
-    complete: true
+    progress: false
+    complete: false
     # Time in seconds of bossbar showed
-    time: 10
+    time: 5
   # Enable/disable ActionBar
   actionbar:
-    progress: true
-    complete: true
+    progress: false
+    complete: false
   # Allow players to have multiple active quests.
   # You can set the default number of quests using the 'default' rank below.
   # To grant different quest limits to different people, you can define a 'quest-rank'

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,4 @@
 rootProject.name = 'Quests'
 include 'common'
-include 'bungee'
 include 'bukkit'
 


### PR DESCRIPTION
Fix #442

New config (put in default one) :
```yml
options:
  bossbar:
    progress: true
    complete: true
    time: 10
  actionbar:
    progress: true
    complete: true
```
Using PlaceholdersAPI's messages : `placeholders.progress` in bossbar/actionbar.

BossBar only for 1.9+
ActionBar only for 1.10+