### PR TITLE
Fix not deleted bossbar

### DIFF
--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/hook/bossbar/BossBar_Bukkit.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/hook/bossbar/BossBar_Bukkit.java
@@ -10,6 +10,7 @@ import org.bukkit.boss.BarColor;
 import org.bukkit.boss.BarStyle;
 import org.bukkit.entity.Player;
 
+import com.google.common.collect.Lists;
 import com.leonardobishop.quests.bukkit.BukkitQuestsPlugin;
 
 public class BossBar_Bukkit implements BossBar {

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/hook/bossbar/BossBar_Bukkit.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/hook/bossbar/BossBar_Bukkit.java
@@ -19,6 +19,13 @@ public class BossBar_Bukkit implements BossBar {
 
     public BossBar_Bukkit(BukkitQuestsPlugin plugin) {
         this.plugin = plugin;
+        String pluginNamespace = new NamespacedKey(plugin, "test").getNamespace(); // get namespace
+        Lists.newArrayList(Bukkit.getBossBars()).forEach(bb -> { // copy list to prevent current modification
+            if(bb.getKey().namespace().equals(pluginNamespace)) {
+                bb.removeAll(); // hide it
+                Bukkit.removeBossBar(bb.getKey()); // remove it
+            }
+        });
         plugin.getScheduler().runTaskTimer(() -> {
             for (Entry<NamespacedKey, Long> entry : new HashMap<>(players).entrySet()) {
                 if (entry.getValue() < System.currentTimeMillis()) {


### PR DESCRIPTION
If you have the bossbar when the server goes down, you will keep the bossbar forever as it's saved in world.

With this PR, it's fixed.

(Thanks Hamta for reporting this issue)