### PR TITLE
Fix not deleted bossbar when stop the server again

### DIFF
--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/hook/bossbar/BossBar_Bukkit.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/hook/bossbar/BossBar_Bukkit.java
@@ -75,7 +75,7 @@ public class BossBar_Bukkit implements QuestsBossBar {
             BossBar bar = questBarCache.asMap()
                     .computeIfAbsent(questId, k -> {
                         //noinspection CodeBlock2Expr (for readability)
-                        return Bukkit.createBossBar(getKeyFor(player, questId), this.barColor, this.barStyle);
+                        return Bukkit.createBossBar(getKeyFor(player, questId), null, this.barColor, this.barStyle);
                     });
 
             bar.setTitle(title);

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/hook/bossbar/BossBar_Bukkit.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/hook/bossbar/BossBar_Bukkit.java
@@ -6,6 +6,7 @@ import com.google.common.cache.RemovalListener;
 import com.google.common.collect.Lists;
 import com.leonardobishop.quests.bukkit.BukkitQuestsPlugin;
 import org.bukkit.Bukkit;
+import org.bukkit.NamespacedKey;
 import org.bukkit.boss.BarColor;
 import org.bukkit.boss.BarStyle;
 import org.bukkit.boss.BossBar;

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/hook/bossbar/BossBar_Bukkit.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/hook/bossbar/BossBar_Bukkit.java
@@ -26,7 +26,15 @@ public class BossBar_Bukkit implements QuestsBossBar {
     public BossBar_Bukkit(BukkitQuestsPlugin plugin) {
         this.plugin = plugin;
         this.removalListener = removal -> plugin.getScheduler().runTask(() -> removal.getValue().removeAll());
-
+        
+        String pluginNamespace = new NamespacedKey(plugin, "quest").getNamespace(); // get namespace
+        Lists.newArrayList(Bukkit.getBossBars()).forEach(bb -> { // copy list to prevent current modification
+            if(bb.getKey().namespace().equals(pluginNamespace)) {
+                bb.removeAll(); // hide it
+                Bukkit.removeBossBar(bb.getKey()); // remove it
+            }
+        });
+        
         try {
             String barColorString = plugin.getQuestsConfig().getString("options.bossbar.color", this.barColor.name());
             this.barColor = BarColor.valueOf(barColorString);
@@ -65,7 +73,7 @@ public class BossBar_Bukkit implements QuestsBossBar {
             BossBar bar = questBarCache.asMap()
                     .computeIfAbsent(questId, k -> {
                         //noinspection CodeBlock2Expr (for readability)
-                        return Bukkit.createBossBar(null, this.barColor, this.barStyle);
+                        return Bukkit.createBossBar(getKeyFor(player, questId), this.barColor, this.barStyle);
                     });
 
             bar.setTitle(title);
@@ -73,5 +81,9 @@ public class BossBar_Bukkit implements QuestsBossBar {
 
             plugin.getScheduler().runTask(() -> bar.addPlayer(player));
         });
+    }
+
+    private NamespacedKey getKeyFor(Player p, String questId) {
+        return new NamespacedKey(plugin, "bossbar_" + p.getName().toLowerCase() + "_" + questId.toLowerCase().replace(" ", ""));
     }
 }

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/hook/bossbar/BossBar_Bukkit.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/hook/bossbar/BossBar_Bukkit.java
@@ -3,6 +3,7 @@ package com.leonardobishop.quests.bukkit.hook.bossbar;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.RemovalListener;
+import com.google.common.collect.Lists;
 import com.leonardobishop.quests.bukkit.BukkitQuestsPlugin;
 import org.bukkit.Bukkit;
 import org.bukkit.boss.BarColor;


### PR DESCRIPTION
It's nice you made changes for async, but with this you re-create a new bug with bossbar that are not disappearing when restarting the sevrer.

Actually, bossbar created and not deleted could not be removed by owner as they are not showed in `/bossbar remove` command.