### PR TITLE
Also allow '_' and '-' to be used as "characters".

### DIFF
--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/util/StringUtils.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/util/StringUtils.java
@@ -5,7 +5,6 @@ package com.leonardobishop.quests.bukkit.util;
  * https://github.com/apache/commons-lang/blob/master/LICENSE.txt
  */
 public class StringUtils {
-
     public static boolean isEmpty(final CharSequence cs) {
         return cs == null || cs.length() == 0;
     }
@@ -14,13 +13,8 @@ public class StringUtils {
         if (isEmpty(cs)) {
             return false;
         }
-        final int sz = cs.length();
-        for (int i = 0; i < sz; i++) {
-            if (!Character.isLetterOrDigit(cs.charAt(i))) {
-                return false;
-            }
-        }
-        return true;
+
+        return cs.chars().allMatch(c -> Character.isLetterOrDigit(c) || c == '_' || c == '-');
     }
 
     public static boolean isNumeric(final CharSequence cs) {


### PR DESCRIPTION
Right now you can't create a quest id like `hunter__passive_mobs__fox`. You have to call it `hunterpassivemobsfox`, which is a lot less readable.
This little change allows for both `-` and `_` to be used in the ids.

I also cleaned up the for loop a little bit.