### PR TITLE
List all available categories when you encounter a missing one.

### DIFF
--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/config/BukkitQuestsLoader.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/config/BukkitQuestsLoader.java
@@ -47,6 +47,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 public class BukkitQuestsLoader implements QuestsLoader {
 
@@ -319,9 +320,10 @@ public class BukkitQuestsLoader implements QuestsLoader {
                             if (c != null) {
                                 c.registerQuestId(id);
                             } else {
+                                String all_categories = questManager.getCategories().stream().map(Category::getId).collect(Collectors.joining(", "));
                                 problems.add(new ConfigProblem(ConfigProblem.ConfigProblemType.WARNING,
-                                        ConfigProblemDescriptions.UNKNOWN_CATEGORY.getDescription(category),
-                                        ConfigProblemDescriptions.UNKNOWN_CATEGORY.getExtendedDescription(category),
+                                        ConfigProblemDescriptions.UNKNOWN_CATEGORY.getDescription(category, all_categories),
+                                        ConfigProblemDescriptions.UNKNOWN_CATEGORY.getExtendedDescription(category, all_categories),
                                         "options.category"));
                             }
                         }

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/config/BukkitQuestsLoader.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/config/BukkitQuestsLoader.java
@@ -320,10 +320,10 @@ public class BukkitQuestsLoader implements QuestsLoader {
                             if (c != null) {
                                 c.registerQuestId(id);
                             } else {
-                                String all_categories = questManager.getCategories().stream().map(Category::getId).collect(Collectors.joining(", "));
+                                String allCategories = questManager.getCategories().stream().map(Category::getId).collect(Collectors.joining(", "));
                                 problems.add(new ConfigProblem(ConfigProblem.ConfigProblemType.WARNING,
-                                        ConfigProblemDescriptions.UNKNOWN_CATEGORY.getDescription(category, all_categories),
-                                        ConfigProblemDescriptions.UNKNOWN_CATEGORY.getExtendedDescription(category, all_categories),
+                                        ConfigProblemDescriptions.UNKNOWN_CATEGORY.getDescription(category, allCategories),
+                                        ConfigProblemDescriptions.UNKNOWN_CATEGORY.getExtendedDescription(category, allCategories),
                                         "options.category"));
                             }
                         }

--- a/common/src/main/java/com/leonardobishop/quests/common/config/ConfigProblemDescriptions.java
+++ b/common/src/main/java/com/leonardobishop/quests/common/config/ConfigProblemDescriptions.java
@@ -102,8 +102,8 @@ public enum ConfigProblemDescriptions {
                     "<dark_grey>-></dark_grey><bold>task-id</bold>:<br>" +
                     "<dark_grey>---></dark_grey>type: ...'"
     ),
-    UNKNOWN_CATEGORY("Category '%s' does not exist",
-            "Category by the ID '%s' does not exist."
+    UNKNOWN_CATEGORY("Category '%s' does not exist (I only know: %s)",
+            "Category by the ID '%s' does not exist. The only known ones are: %s"
     ),
     UNKNOWN_REQUIREMENT("Quest requirement '%s' does not exist",
                     "This may be the result of a cascading error<br>" +


### PR DESCRIPTION
Output:
```
[09:33:18 INFO]: example6.yml ----
[09:33:18 INFO]:  | - W: Category 'permissionexample' does not exist (I only know: Tutorial, Hunter, Miner) :options.category
```

This is much easier for debugging, especially if you mistyped a character.