### PR TITLE
Set back button to correct slot if GUI trim is off

### DIFF
--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/menu/PaginatedQMenu.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/menu/PaginatedQMenu.java
@@ -133,7 +133,8 @@ public abstract class PaginatedQMenu extends QMenu {
 
             // else find a place for the back button if needed
         } else if (backMenuElement != null && backMenuElement.isEnabled()) {
-            int slot = MenuUtils.getHigherOrEqualMultiple(menuElements.size() + menuElementsToFill.size() + customStaticElements, 9);
+            int slot = trim ? MenuUtils.getHigherOrEqualMultiple(menuElements.size() + menuElementsToFill.size() + customStaticElements, 9) 
+                            : backMenuElement.getSlot(); // place the back button at the defined slot
             staticMenuElements[slot] = backMenuElement;
         }
 


### PR DESCRIPTION
The current behavior is that the back button is placed on the first slot of the first empty row if there's only a single GUI page.

This PR changes this behavior to account for the `options.trim-gui-size` option. This way, if `trim-gui-size` is set to `false`, the back button is placed at the `gui.back-button.slot` slot instead. This ensures consistent placement whether the GUI gets paginated or not (since it has 54 slots anyways), and allows for the untrimmed space to actually be used.

Edit: Also partially fixes #378 I guess?