### PR TITLE
Fix quests occupying pagination row slots

### DIFF
--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/menu/PaginatedQMenu.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/menu/PaginatedQMenu.java
@@ -124,12 +124,10 @@ public abstract class PaginatedQMenu extends QMenu {
             PageNextMenuElement pageNextMenuElement = new PageNextMenuElement(config, this);
             PagePrevMenuElement pagePrevMenuElement = new PagePrevMenuElement(config, this);
             PageDescMenuElement pageDescMenuElement = new PageDescMenuElement(config, this);
-            // add manually spacer then let people change item
-            staticMenuElements[46] = spacer;
-            staticMenuElements[47] = spacer;
-            staticMenuElements[51] = spacer;
-            staticMenuElements[52] = spacer;
-            staticMenuElements[53] = spacer;
+
+            // manually add spacers to the bottom row, then let people change items
+            for (int i = 45; i < 54; staticMenuElements[i++] = spacer);
+
             if(backMenuElement != null && backMenuElement.isEnabled())
                 staticMenuElements[backMenuElement.getSlot()] = backMenuElement == null ? spacer : backMenuElement;
             if(pagePrevMenuElement.isEnabled())


### PR DESCRIPTION
Spacers are currently manually added to slots 46, 47, 51, 52 and 53 in paginated menus, assuming slots 45, 48, 49 and 50 will always be occupied.

If users disable any of the pagination buttons or move them to any of the spacer slots, the quests bleed through to the bottom row. The issue is also apparent when using `/quests category <some paginated category>`, as the "back" button isn't present there and one of the quests from the next page simply occupies what would have been the back button slot (see [example](https://i.imgur.com/GBIZqRn.png)).

This PR fixes this behavior by manually adding spacers to the whole bottom row of paginated menus.