### PR TITLE
Add GUI trimming options per GUI type

### DIFF
--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/menu/CategoryQMenu.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/menu/CategoryQMenu.java
@@ -21,7 +21,7 @@ public class CategoryQMenu extends PaginatedQMenu {
 
     public CategoryQMenu(BukkitQuestsPlugin plugin, QPlayer owner) {
         super(owner, Chat.legacyColor(plugin.getQuestsConfig().getString("options.guinames.quests-category")),
-                plugin.getQuestsConfig().getBoolean("options.trim-gui-size"), 54, plugin);
+                plugin.getQuestsConfig().getBoolean("options.trim-gui-size.quests-category-menu"), 54, plugin);
 
         BukkitQuestsConfig config = (BukkitQuestsConfig) plugin.getQuestsConfig();
 

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/menu/QuestQMenu.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/menu/QuestQMenu.java
@@ -24,7 +24,7 @@ public class QuestQMenu extends PaginatedQMenu {
 
     public QuestQMenu(BukkitQuestsPlugin plugin, QPlayer owner, List<Quest> quests, String categoryName, CategoryQMenu categoryQMenu) {
         super(owner, Chat.legacyColor(plugin.getQuestsConfig().getString("options.guinames.quests-menu")),
-                plugin.getQuestsConfig().getBoolean("options.trim-gui-size"), 54, plugin);
+                plugin.getQuestsConfig().getBoolean("options.trim-gui-size.quests-menu"), 54, plugin);
 
         BukkitQuestsConfig config = (BukkitQuestsConfig) plugin.getQuestsConfig();
         this.categoryName = categoryName;

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/menu/StartedQMenu.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/menu/StartedQMenu.java
@@ -17,7 +17,7 @@ public class StartedQMenu extends PaginatedQMenu {
 
     public StartedQMenu(BukkitQuestsPlugin plugin, QPlayer owner, List<Quest> quests) {
         super(owner, Chat.legacyColor(plugin.getQuestsConfig().getString("options.guinames.quests-started-menu")),
-                plugin.getQuestsConfig().getBoolean("options.trim-gui-size"), 54, plugin);
+                plugin.getQuestsConfig().getBoolean("options.trim-gui-size.quests-started-menu"), 54, plugin);
 
         List<MenuElement> elements = new ArrayList<>();
 

--- a/bukkit/src/main/resources/resources/bukkit/config.yml
+++ b/bukkit/src/main/resources/resources/bukkit/config.yml
@@ -33,7 +33,10 @@ options:
   # If categories are disabled, quests will be put into one big gui.
   categories-enabled: true
   # If true, the gui size will automatically change based on the amount of quests inside it.
-  trim-gui-size: true
+  trim-gui-size:
+    quests-category-menu: true
+    quests-menu: true
+    quests-started-menu: true
   # Enable/disable titles
   titles-enabled: true
   # Enable/disable BossBars

--- a/docs/configuration/basic-options.md
+++ b/docs/configuration/basic-options.md
@@ -54,7 +54,10 @@ of rows) so that there are not any empty rows.
 ``` yaml
 options:
   # ...
-  trim-gui-size: true
+  trim-gui-size:
+    quests-category-menu: true
+    quests-menu: true
+    quests-started-menu: true
 ```
 
 ## Titles enabled


### PR DESCRIPTION
Allows for better customization - especially useful for people looking to add custom GUI overlays through resource packs, but don't want to trim all the guis