### PR TITLE
Added lacking information to smithing-(task-type).md

### DIFF
--- a/docs/task-types/smithing-(task-type).md
+++ b/docs/task-types/smithing-(task-type).md
@@ -20,6 +20,7 @@ Smith a certain number of items using a smithing table.
 |---------------|--------------------------------------------------------|------------------------|----------|---------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `amount`      | The number of items to smith.                          | Integer                | Yes      | \-      | \-                                                                                                                                                                                                                                                                                                                          |
 | `item`        | The specific item to smith.                            | Material, or ItemStack | No       | \-      | Accepts standard [item definition](../configuration/defining-items). Please see [this list](https://hub.spigotmc.org/javadocs/bukkit/org/bukkit/Material.html) (1.13+) or [this list](https://helpch.at/docs/1.12.2/org/bukkit/Material.html) (1.8-1.12) for material names. If this is not specified, any item will count. |
+| `mode`        | The specific mode of smithing.                         | String                 | Yes      | \-      | One of: `transform`, `trim`. |
 | `worlds`      | Worlds which should count towards the progress.        | List of world names    | No       | \-      | \-                                                                                                                                                                                                                                                                                                                          |
 | `exact-match` | Whether the item should exactly match what is defined. | Boolean                | No       | true    | \-                                                                                                                                                                                                                                                                                                                          |
 
@@ -31,6 +32,7 @@ Smith 10 items:
 smithing:
   type: "smithing"
   amount: 10                            # amount to smith
+  mode: "transform"                     # mode of smithing
   worlds:                               # (OPTIONAL) restrict to certain worlds
    - "world"
 ```


### PR DESCRIPTION
New commit changed the smithing type quest and now is required to specify a mode. Not specifying a mode will break the quest since is a required field. The mode options was not specified, not even in the commit.