### PR TITLE
Add item breaking, mending and damaging; curing and resurrecting task types

### DIFF
--- a/bukkit/build.gradle
+++ b/bukkit/build.gradle
@@ -32,6 +32,8 @@ repositories {
     maven { url = 'https://mvn.lumine.io/repository/maven-public/' }
     // NuVotifier
     maven { url = 'https://repo.leonardobishop.com/releases/' }
+    // Oraxen
+    maven { url = 'https://repo.oraxen.com/releases' }
     // PlaceholderAPI
     maven { url = 'https://repo.extendedclip.com/content/repositories/dev/' }
     // CustomFishing, ItemsAdder, SCore, ShopGUIPlus, Slimefun4
@@ -104,6 +106,8 @@ dependencies {
     compileOnly 'io.lumine:Mythic-Dist:5.2.0'
     // NuVotifier
     compileOnly 'com.vexsoftware:NuVotifier:2.7.3'
+    // Oraxen
+    compileOnly('io.th0rgal:oraxen:1.175.0') { transitive = false }
     // PlaceholderAPI
     compileOnly 'me.clip:placeholderapi:2.11.3-DEV-160'
     // PlayerPoints

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/BukkitQuestsPlugin.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/BukkitQuestsPlugin.java
@@ -165,6 +165,7 @@ import java.io.OutputStream;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.function.BiFunction;
@@ -340,7 +341,7 @@ public class BukkitQuestsPlugin extends JavaPlugin implements Quests {
         questsConfig.setItemGetter(itemGetter);
 
         // Finish module initialisation
-        this.taskTypeManager = new BukkitTaskTypeManager(this, questsConfig.getStringList("options.task-type-exclusions"));
+        this.taskTypeManager = new BukkitTaskTypeManager(this, new HashSet<>(questsConfig.getStringList("options.task-type-exclusions")));
         this.qPlayerManager = new QPlayerManager(this, storageProvider, questController);
         this.menuController = new MenuController(this);
         this.questItemRegistry = new QuestItemRegistry();

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/BukkitQuestsPlugin.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/BukkitQuestsPlugin.java
@@ -523,8 +523,8 @@ public class BukkitQuestsPlugin extends JavaPlugin implements Quests {
 
     private @NotNull String getRegistrationMessage() {
         final int registered = this.taskTypeManager.getRegistered();
-        final int skipped = taskTypeManager.getSkipped();
-        final int unsupported = taskTypeManager.getUnsupported();
+        final int skipped = this.taskTypeManager.getSkipped();
+        final int unsupported = this.taskTypeManager.getUnsupported();
 
         final StringBuilder sb = new StringBuilder();
         sb.append(registered).append(" task types have been registered");

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/BukkitQuestsPlugin.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/BukkitQuestsPlugin.java
@@ -64,6 +64,7 @@ import com.leonardobishop.quests.bukkit.tasktype.type.BlockshearingTaskType;
 import com.leonardobishop.quests.bukkit.tasktype.type.BreedingTaskType;
 import com.leonardobishop.quests.bukkit.tasktype.type.BrewingTaskType;
 import com.leonardobishop.quests.bukkit.tasktype.type.BucketEmptyTaskType;
+import com.leonardobishop.quests.bukkit.tasktype.type.BucketEntityTaskType;
 import com.leonardobishop.quests.bukkit.tasktype.type.BucketFillTaskType;
 import com.leonardobishop.quests.bukkit.tasktype.type.BuildingTaskType;
 import com.leonardobishop.quests.bukkit.tasktype.type.CommandTaskType;
@@ -444,6 +445,7 @@ public class BukkitQuestsPlugin extends JavaPlugin implements Quests {
             taskTypeManager.registerTaskType(() -> new BlockItemdroppingTaskType(this), () -> CompatUtils.classExists("org.bukkit.event.block.BlockDropItemEvent"));
             taskTypeManager.registerTaskType(() -> new BlockshearingTaskType(this), () -> CompatUtils.classExists("io.papermc.paper.event.block.PlayerShearBlockEvent"));
             taskTypeManager.registerTaskType(() -> new BrewingTaskType(this), () -> CompatUtils.classWithMethodExists("org.bukkit.event.inventory.BrewEvent", "getResults"));
+            taskTypeManager.registerTaskType(() -> new BucketEntityTaskType(this), () -> CompatUtils.classExists("org.bukkit.event.player.PlayerBucketEntityEvent"));
             taskTypeManager.registerTaskType(() -> new CompostingTaskType(this), () -> CompatUtils.classExists("io.papermc.paper.event.entity.EntityCompostItemEvent"));
             taskTypeManager.registerTaskType(() -> new CuringTaskType(this), () -> CompatUtils.classExists("org.bukkit.event.entity.EntityTransformEvent"));
             taskTypeManager.registerTaskType(() -> new FarmingTaskType(this), () -> CompatUtils.classExists("org.bukkit.block.data.Ageable"));

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/BukkitQuestsPlugin.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/BukkitQuestsPlugin.java
@@ -79,6 +79,9 @@ import com.leonardobishop.quests.bukkit.tasktype.type.FishingTaskType;
 import com.leonardobishop.quests.bukkit.tasktype.type.HatchingTaskType;
 import com.leonardobishop.quests.bukkit.tasktype.type.InteractTaskType;
 import com.leonardobishop.quests.bukkit.tasktype.type.InventoryTaskType;
+import com.leonardobishop.quests.bukkit.tasktype.type.ItembreakingTaskType;
+import com.leonardobishop.quests.bukkit.tasktype.type.ItemdamagingTaskType;
+import com.leonardobishop.quests.bukkit.tasktype.type.ItemmendingTaskType;
 import com.leonardobishop.quests.bukkit.tasktype.type.MilkingTaskType;
 import com.leonardobishop.quests.bukkit.tasktype.type.MiningTaskType;
 import com.leonardobishop.quests.bukkit.tasktype.type.MobkillingTaskType;
@@ -420,6 +423,8 @@ public class BukkitQuestsPlugin extends JavaPlugin implements Quests {
             taskTypeManager.registerTaskType(new FishingTaskType(this));
             taskTypeManager.registerTaskType(new InteractTaskType(this));
             taskTypeManager.registerTaskType(new InventoryTaskType(this));
+            taskTypeManager.registerTaskType(new ItembreakingTaskType(this));
+            taskTypeManager.registerTaskType(new ItemdamagingTaskType(this));
             taskTypeManager.registerTaskType(new MilkingTaskType(this));
             taskTypeManager.registerTaskType(new MiningTaskType(this));
             taskTypeManager.registerTaskType(new MobkillingTaskType(this));
@@ -440,6 +445,7 @@ public class BukkitQuestsPlugin extends JavaPlugin implements Quests {
             taskTypeManager.registerTaskType(() -> new CompostingTaskType(this), () -> CompatUtils.classExists("io.papermc.paper.event.entity.EntityCompostItemEvent"));
             taskTypeManager.registerTaskType(() -> new FarmingTaskType(this), () -> CompatUtils.classExists("org.bukkit.block.data.Ageable"));
             taskTypeManager.registerTaskType(() -> new HatchingTaskType(this), () -> CompatUtils.classExists("com.destroystokyo.paper.event.entity.ThrownEggHatchEvent"));
+            taskTypeManager.registerTaskType(() -> new ItemmendingTaskType(this), () -> CompatUtils.classExists("org.bukkit.event.player.PlayerItemMendEvent"));
             taskTypeManager.registerTaskType(() -> new ReplenishingTaskType(this), () -> CompatUtils.classExists("com.destroystokyo.paper.loottable.LootableInventoryReplenishEvent"));
             taskTypeManager.registerTaskType(() -> new SmithingTaskType(this), () -> CompatUtils.classExists("org.bukkit.event.inventory.SmithItemEvent"));
 

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/BukkitQuestsPlugin.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/BukkitQuestsPlugin.java
@@ -493,7 +493,7 @@ public class BukkitQuestsPlugin extends JavaPlugin implements Quests {
             });
 
             // Register task types with even more weird requirements
-            if (Bukkit.getPluginManager().isPluginEnabled("BentoBox")) {
+            if (CompatUtils.isPluginEnabled("BentoBox")) {
                 BentoBoxLevelTaskType.register(this, taskTypeManager);
             }
 
@@ -501,18 +501,8 @@ public class BukkitQuestsPlugin extends JavaPlugin implements Quests {
             taskTypeManager.closeRegistrations();
 
             // Inform about registered task types
-            String registrationMessage = taskTypeManager.getTaskTypes().size() + " task types have been registered";
-            int skipped = taskTypeManager.getSkipped();
-            int unsupported = taskTypeManager.getUnsupported();
-            if (skipped + unsupported > 0) {
-                registrationMessage += " (";
-                if (skipped > 0) registrationMessage += skipped + " skipped due to exclusions or conflicting names";
-                if (skipped * unsupported > 0) registrationMessage += ", ";
-                if (unsupported > 0) registrationMessage += unsupported + " not supported";
-                registrationMessage += ")";
-            }
-            registrationMessage += ".";
-            questsLogger.info(registrationMessage);
+            final String registrationMessage = this.getRegistrationMessage();
+            this.questsLogger.info(registrationMessage);
 
             if (playerBlockTrackerHook != null) {
                 this.playerBlockTrackerHook.fixPlayerBlockTracker();
@@ -529,6 +519,36 @@ public class BukkitQuestsPlugin extends JavaPlugin implements Quests {
                 qPlayerManager.loadPlayer(player.getUniqueId());
             }
         });
+    }
+
+    private @NotNull String getRegistrationMessage() {
+        final int registered = this.taskTypeManager.getRegistered();
+        final int skipped = taskTypeManager.getSkipped();
+        final int unsupported = taskTypeManager.getUnsupported();
+
+        final StringBuilder sb = new StringBuilder();
+        sb.append(registered).append(" task types have been registered");
+
+        if (skipped + unsupported > 0) {
+            sb.append(' ').append(')');
+
+            if (skipped > 0) {
+                sb.append(skipped).append(" skipped due to exclusions or conflicting names");
+            }
+
+            if (skipped * unsupported > 0) {
+                sb.append(',').append(' ');
+            }
+
+            if (unsupported > 0) {
+                sb.append(unsupported).append(" not supported");
+            }
+
+            sb.append(')');
+        }
+
+        sb.append('.');
+        return sb.toString();
     }
 
     @Override

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/BukkitQuestsPlugin.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/BukkitQuestsPlugin.java
@@ -70,6 +70,7 @@ import com.leonardobishop.quests.bukkit.tasktype.type.CommandTaskType;
 import com.leonardobishop.quests.bukkit.tasktype.type.CompostingTaskType;
 import com.leonardobishop.quests.bukkit.tasktype.type.ConsumeTaskType;
 import com.leonardobishop.quests.bukkit.tasktype.type.CraftingTaskType;
+import com.leonardobishop.quests.bukkit.tasktype.type.CuringTaskType;
 import com.leonardobishop.quests.bukkit.tasktype.type.DealDamageTaskType;
 import com.leonardobishop.quests.bukkit.tasktype.type.DistancefromTaskType;
 import com.leonardobishop.quests.bukkit.tasktype.type.EnchantingTaskType;
@@ -443,6 +444,7 @@ public class BukkitQuestsPlugin extends JavaPlugin implements Quests {
             taskTypeManager.registerTaskType(() -> new BlockshearingTaskType(this), () -> CompatUtils.classExists("io.papermc.paper.event.block.PlayerShearBlockEvent"));
             taskTypeManager.registerTaskType(() -> new BrewingTaskType(this), () -> CompatUtils.classWithMethodExists("org.bukkit.event.inventory.BrewEvent", "getResults"));
             taskTypeManager.registerTaskType(() -> new CompostingTaskType(this), () -> CompatUtils.classExists("io.papermc.paper.event.entity.EntityCompostItemEvent"));
+            taskTypeManager.registerTaskType(() -> new CuringTaskType(this), () -> CompatUtils.classExists("org.bukkit.event.entity.EntityTransformEvent"));
             taskTypeManager.registerTaskType(() -> new FarmingTaskType(this), () -> CompatUtils.classExists("org.bukkit.block.data.Ageable"));
             taskTypeManager.registerTaskType(() -> new HatchingTaskType(this), () -> CompatUtils.classExists("com.destroystokyo.paper.event.entity.ThrownEggHatchEvent"));
             taskTypeManager.registerTaskType(() -> new ItemmendingTaskType(this), () -> CompatUtils.classExists("org.bukkit.event.player.PlayerItemMendEvent"));

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/BukkitQuestsPlugin.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/BukkitQuestsPlugin.java
@@ -503,7 +503,15 @@ public class BukkitQuestsPlugin extends JavaPlugin implements Quests {
             // Inform about registered task types
             String registrationMessage = taskTypeManager.getTaskTypes().size() + " task types have been registered";
             int skipped = taskTypeManager.getSkipped();
-            registrationMessage += (skipped > 0) ? " (" + skipped + " skipped due to exclusions or conflicting names)." : ".";
+            int unsupported = taskTypeManager.getUnsupported();
+            if (skipped + unsupported > 0) {
+                registrationMessage += " (";
+                if (skipped > 0) registrationMessage += skipped + " skipped due to exclusions or conflicting names";
+                if (skipped * unsupported > 0) registrationMessage += ", ";
+                if (unsupported > 0) registrationMessage += unsupported + " not supported";
+                registrationMessage += ")";
+            }
+            registrationMessage += ".";
             questsLogger.info(registrationMessage);
 
             if (playerBlockTrackerHook != null) {

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/BukkitQuestsPlugin.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/BukkitQuestsPlugin.java
@@ -530,7 +530,7 @@ public class BukkitQuestsPlugin extends JavaPlugin implements Quests {
         sb.append(registered).append(" task types have been registered");
 
         if (skipped + unsupported > 0) {
-            sb.append(' ').append(')');
+            sb.append(' ').append('(');
 
             if (skipped > 0) {
                 sb.append(skipped).append(" skipped due to exclusions or conflicting names");

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/BukkitQuestsPlugin.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/BukkitQuestsPlugin.java
@@ -602,7 +602,7 @@ public class BukkitQuestsPlugin extends JavaPlugin implements Quests {
             long autoSaveInterval = this.getConfig().getLong("options.performance-tweaking.quest-autosave-interval", 12000);
             try {
                 if (questAutoSaveTask != null) questAutoSaveTask.cancel();
-                questAutoSaveTask = new QuestsAutoSaveRunnable(this).runTaskTimer(getScheduler(), autoSaveInterval, autoSaveInterval);
+                questAutoSaveTask = serverScheduler.runTaskTimer(() -> new QuestsAutoSaveRunnable(this), autoSaveInterval, autoSaveInterval);
             } catch (Exception ex) {
                 questsLogger.debug("Cannot cancel and restart quest autosave task");
             }

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/BukkitQuestsPlugin.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/BukkitQuestsPlugin.java
@@ -92,6 +92,7 @@ import com.leonardobishop.quests.bukkit.tasktype.type.PlaytimeTaskType;
 import com.leonardobishop.quests.bukkit.tasktype.type.PositionTaskType;
 import com.leonardobishop.quests.bukkit.tasktype.type.ProjectilelaunchingTaskType;
 import com.leonardobishop.quests.bukkit.tasktype.type.ReplenishingTaskType;
+import com.leonardobishop.quests.bukkit.tasktype.type.ResurrectingTaskType;
 import com.leonardobishop.quests.bukkit.tasktype.type.ShearingTaskType;
 import com.leonardobishop.quests.bukkit.tasktype.type.SmeltingTaskType;
 import com.leonardobishop.quests.bukkit.tasktype.type.SmithingTaskType;
@@ -449,6 +450,7 @@ public class BukkitQuestsPlugin extends JavaPlugin implements Quests {
             taskTypeManager.registerTaskType(() -> new HatchingTaskType(this), () -> CompatUtils.classExists("com.destroystokyo.paper.event.entity.ThrownEggHatchEvent"));
             taskTypeManager.registerTaskType(() -> new ItemmendingTaskType(this), () -> CompatUtils.classExists("org.bukkit.event.player.PlayerItemMendEvent"));
             taskTypeManager.registerTaskType(() -> new ReplenishingTaskType(this), () -> CompatUtils.classExists("com.destroystokyo.paper.loottable.LootableInventoryReplenishEvent"));
+            taskTypeManager.registerTaskType(() -> new ResurrectingTaskType(this), () -> CompatUtils.classExists("org.bukkit.event.entity.EntityResurrectEvent"));
             taskTypeManager.registerTaskType(() -> new SmithingTaskType(this), () -> CompatUtils.classExists("org.bukkit.event.inventory.SmithItemEvent"));
 
             // Register task types with enabled plugin compatibility requirement

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/command/AdminDebugQuestCommandHandler.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/command/AdminDebugQuestCommandHandler.java
@@ -11,12 +11,13 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 public class AdminDebugQuestCommandHandler implements CommandHandler {
 
     private final BukkitQuestsPlugin plugin;
-
 
     public AdminDebugQuestCommandHandler(BukkitQuestsPlugin plugin) {
         this.plugin = plugin;
@@ -69,10 +70,18 @@ public class AdminDebugQuestCommandHandler implements CommandHandler {
                         ". This may generate a lot of spam.");
                 sender.sendMessage(ChatColor.GRAY + "Use '/quests admin debug " + questId + "' to disable.");
             } else {
-                preferences.setDebug(questId, null);
+                preferences.unsetDebug(questId);
                 sender.sendMessage(ChatColor.GREEN + "Debugging disabled for " + questName + ".");
             }
 
+            // Set it here to optimize debugging on high player count servers
+            final Set<QPlayer> debuggers = new HashSet<>();
+            for (final QPlayer debugger : this.plugin.getPlayerManager().getQPlayers()) {
+                if (debugger.getPlayerPreferences().isDebug()) {
+                    debuggers.add(debugger);
+                }
+            }
+            QPlayerPreferences.setDebuggers(debuggers);
         } else {
             sender.sendMessage(ChatColor.RED + "You must be a player to use this command.");
         }

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/command/QuestsCommandSwitcher.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/command/QuestsCommandSwitcher.java
@@ -39,7 +39,7 @@ public class QuestsCommandSwitcher extends CommandSwitcher implements TabExecuto
 
     @Override
     public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String[] args) {
-        if (plugin.getTaskTypeManager().areRegistrationsAccepted()) {
+        if (plugin.getTaskTypeManager().areRegistrationsOpen()) {
             sender.sendMessage(ChatColor.RED + "Quests is not ready yet.");
             return true;
         }

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/config/BukkitQuestsLoader.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/config/BukkitQuestsLoader.java
@@ -383,7 +383,7 @@ public class BukkitQuestsLoader implements QuestsLoader {
                         questManager.registerQuest(quest);
                         taskTypeManager.registerQuestTasksWithTaskTypes(quest);
                         qItemStackRegistry.register(quest, displayItem);
-                        if (config.isConfigurationSection("options.started-display")) {
+                        if (config.isConfigurationSection("options.locked-display")) {
                             qItemStackRegistry.registerQuestLocked(quest,
                                     plugin.getItemGetter().getItem("options.locked-display", config));
                         }

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/config/BukkitQuestsLoader.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/config/BukkitQuestsLoader.java
@@ -5,6 +5,7 @@ import com.leonardobishop.quests.bukkit.hook.itemgetter.ItemGetter;
 import com.leonardobishop.quests.bukkit.item.ExecutableItemsQuestItem;
 import com.leonardobishop.quests.bukkit.item.ItemsAdderQuestItem;
 import com.leonardobishop.quests.bukkit.item.MMOItemsQuestItem;
+import com.leonardobishop.quests.bukkit.item.OraxenQuestItem;
 import com.leonardobishop.quests.bukkit.item.ParsedQuestItem;
 import com.leonardobishop.quests.bukkit.item.QuestItem;
 import com.leonardobishop.quests.bukkit.item.QuestItemRegistry;
@@ -494,6 +495,10 @@ public class BukkitQuestsLoader implements QuestsLoader {
                         case "itemsadder":
                             if (!Bukkit.getPluginManager().isPluginEnabled("ItemsAdder")) return FileVisitResult.CONTINUE;
                             item = new ItemsAdderQuestItem(id, config.getString("item.id"));
+                            break;
+                        case "oraxen":
+                            if (!Bukkit.getPluginManager().isPluginEnabled("Oraxen")) return FileVisitResult.CONTINUE;
+                            item = new OraxenQuestItem(id, config.getString("item.id"));
                             break;
                     }
 

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/config/BukkitQuestsLoader.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/config/BukkitQuestsLoader.java
@@ -270,6 +270,8 @@ public class BukkitQuestsLoader implements QuestsLoader {
                         List<String> requirements = config.getStringList("options.requires");
                         List<String> rewardString = config.getStringList("rewardstring");
                         List<String> startString = config.getStringList("startstring");
+                        List<String> cancelString = config.getStringList("cancelstring");
+                        List<String> expiryString = config.getStringList("expirystring");
                         List<String> startCommands = config.getStringList("startcommands");
                         List<String> cancelCommands = config.getStringList("cancelcommands");
                         List<String> expiryCommands = config.getStringList("expirycommands");
@@ -302,6 +304,8 @@ public class BukkitQuestsLoader implements QuestsLoader {
                                 .withRequirements(requirements)
                                 .withRewardString(rewardString)
                                 .withStartString(startString)
+                                .withCancelString(cancelString)
+                                .withExpiryString(expiryString)
                                 .withStartCommands(startCommands)
                                 .withCancelCommands(cancelCommands)
                                 .withExpiryCommands(expiryCommands)

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/config/BukkitQuestsLoader.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/config/BukkitQuestsLoader.java
@@ -43,8 +43,10 @@ import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -222,7 +224,7 @@ public class BukkitQuestsLoader implements QuestsLoader {
                                     configValues.put(key, config.get(taskRoot + "." + key));
                                 }
 
-                                List<ConfigProblem> taskProblems = new ArrayList<>();
+                                Set<ConfigProblem> taskProblems = new HashSet<>();
                                 for (TaskType.ConfigValidator validator : t.getConfigValidators()) {
                                     validator.validateConfig(configValues, taskProblems);
                                 }

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/hook/bossbar/BossBar_Bukkit.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/hook/bossbar/BossBar_Bukkit.java
@@ -121,7 +121,9 @@ public class BossBar_Bukkit implements QuestsBossBar {
                 throw new IllegalStateException(type + " section is empty");
             }
         } catch (IllegalArgumentException | IllegalStateException e) {
-            plugin.getLogger().log(Level.SEVERE, "Could not set " + type + " for the initialized boss bar implementation, using default instead!", e);
+            plugin.getLogger().log(Level.SEVERE, "Could not set " + type + " for the initialized boss bar implementation, using default instead!");
+            plugin.getLogger().log(Level.SEVERE, "Update your config to latest version! (" + e.getMessage() + ")");
+            plugin.getLogger().log(Level.SEVERE, "https://github.com/LMBishop/Quests/blob/master/bukkit/src/main/resources/resources/bukkit/config.yml");
             map = Collections.singletonMap(0.0f, def);
         }
         return map;

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/hook/versionspecific/VersionSpecificHandler20.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/hook/versionspecific/VersionSpecificHandler20.java
@@ -11,6 +11,11 @@ import org.bukkit.inventory.SmithingTrimRecipe;
 public class VersionSpecificHandler20 extends VersionSpecificHandler17 implements VersionSpecificHandler {
 
     @Override
+    public int getMinecraftVersion() {
+        return 20;
+    }
+
+    @Override
     public boolean isPlayerOnCamel(Player player) {
         return player.getVehicle() instanceof Camel;
     }

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/item/OraxenQuestItem.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/item/OraxenQuestItem.java
@@ -1,0 +1,25 @@
+package com.leonardobishop.quests.bukkit.item;
+
+import io.th0rgal.oraxen.api.OraxenItems;
+import org.bukkit.inventory.ItemStack;
+
+public class OraxenQuestItem extends QuestItem {
+
+    private final String oraxenId;
+
+    public OraxenQuestItem(String id, String oraxenId) {
+        super("oraxen", id);
+        this.oraxenId = oraxenId;
+    }
+
+    @Override
+    public ItemStack getItemStack() {
+        return OraxenItems.getItemById(this.oraxenId).build();
+    }
+
+    @Override
+    public boolean compareItemStack(ItemStack other, boolean exactMatch) {
+        final String otherId = OraxenItems.getIdByItem(other);
+        return this.oraxenId.equals(otherId);
+    }
+}

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/questcontroller/NormalQuestController.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/questcontroller/NormalQuestController.java
@@ -302,6 +302,12 @@ public class NormalQuestController implements QuestController {
                     Bukkit.getServer().dispatchCommand(Bukkit.getConsoleSender(), s);
                 }
             }
+            for (String s : quest.getCancelString()) {
+                if (plugin.getConfig().getBoolean("options.quests-use-placeholderapi")) {
+                    s = plugin.getPlaceholderAPIProcessor().apply(player, s);
+                }
+                player.sendMessage(Chat.legacyColor(s));
+            }
             SoundUtils.playSoundForPlayer(player, plugin.getQuestsConfig().getString("options.sounds.quest-cancel"));
         }
         if (config.getBoolean("options.allow-quest-track")
@@ -336,6 +342,12 @@ public class NormalQuestController implements QuestController {
                 } else {
                     Bukkit.getServer().dispatchCommand(Bukkit.getConsoleSender(), s);
                 }
+            }
+            for (String s : quest.getExpiryString()) {
+                if (plugin.getConfig().getBoolean("options.quests-use-placeholderapi")) {
+                    s = plugin.getPlaceholderAPIProcessor().apply(player, s);
+                }
+                player.sendMessage(Chat.legacyColor(s));
             }
         }
         if (config.getBoolean("options.allow-quest-track")

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/BukkitTaskType.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/BukkitTaskType.java
@@ -15,6 +15,10 @@ public abstract class BukkitTaskType extends TaskType implements Listener {
         super(type, author, description, aliases);
     }
 
+    public BukkitTaskType(final @NotNull String type, final @Nullable String author, final @Nullable String description) {
+        super(type, author, description);
+    }
+
     public BukkitTaskType(final @NotNull String type) {
         super(type);
     }

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/BukkitTaskType.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/BukkitTaskType.java
@@ -3,6 +3,7 @@ package com.leonardobishop.quests.bukkit.tasktype;
 import com.leonardobishop.quests.common.tasktype.TaskType;
 import org.bukkit.event.Listener;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.UUID;
 
@@ -10,20 +11,15 @@ public abstract class BukkitTaskType extends TaskType implements Listener {
 
     protected BukkitTaskTypeManager taskTypeManager;
 
-    public BukkitTaskType(@NotNull String type, String author, String description, String... aliases) {
+    public BukkitTaskType(final @NotNull String type, final @Nullable String author, final @Nullable String description, final @NotNull String @NotNull ... aliases) {
         super(type, author, description, aliases);
     }
 
-    public BukkitTaskType(@NotNull String type, String author, String description) {
-        super(type, author, description);
-    }
-
-    public BukkitTaskType(@NotNull String type) {
+    public BukkitTaskType(final @NotNull String type) {
         super(type);
     }
 
-    public final void debug(@NotNull String message, String questId, String taskId, @NotNull UUID player) {
-        taskTypeManager.sendDebug(message, super.getType(), questId, taskId, player);
+    public final void debug(final @NotNull String message, final @NotNull String questId, final @NotNull String taskId, final @NotNull UUID player) {
+        this.taskTypeManager.sendDebug(message, this.type, questId, taskId, player);
     }
-
 }

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/BukkitTaskTypeManager.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/BukkitTaskTypeManager.java
@@ -5,55 +5,89 @@ import com.leonardobishop.quests.common.player.QPlayer;
 import com.leonardobishop.quests.common.player.QPlayerPreferences;
 import com.leonardobishop.quests.common.tasktype.TaskType;
 import com.leonardobishop.quests.common.tasktype.TaskTypeManager;
-import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 
-public class BukkitTaskTypeManager extends TaskTypeManager {
+/**
+ * The Bukkit task type manager stores all registered Bukkit-specific task types and registers individual quests to each task type.
+ * This manager ensures that task types specific to Bukkit are registered and handled correctly.
+ */
+public final class BukkitTaskTypeManager extends TaskTypeManager {
 
     private final BukkitQuestsPlugin plugin;
 
-    public BukkitTaskTypeManager(BukkitQuestsPlugin plugin) {
+    /**
+     * Constructs a new BukkitTaskTypeManager.
+     *
+     * @param plugin the Bukkit plugin instance
+     */
+    public BukkitTaskTypeManager(final @NotNull BukkitQuestsPlugin plugin) {
         this.plugin = plugin;
     }
 
-    public BukkitTaskTypeManager(BukkitQuestsPlugin plugin, List<String> exclusions) {
+    /**
+     * Constructs a new BukkitTaskTypeManager with exclusions.
+     *
+     * @param plugin the Bukkit plugin instance
+     * @param exclusions the set of task type exclusions
+     */
+    public BukkitTaskTypeManager(final @NotNull BukkitQuestsPlugin plugin, final @NotNull Set<String> exclusions) {
         super(exclusions);
         this.plugin = plugin;
     }
 
+    /**
+     * Registers a Bukkit-specific task type with the task type manager.
+     *
+     * @param taskType the task type to register
+     * @return true if the task type was successfully registered, false otherwise
+     * @throws RuntimeException if the task type is not an instance of {@link BukkitTaskType}
+     */
     @Override
-    public boolean registerTaskType(@NotNull TaskType taskType) {
-        if (!(taskType instanceof BukkitTaskType bukkitTaskType)) throw new RuntimeException("BukkitTaskTypeManager implementation can only accept instances of BukkitTaskType!");
+    public boolean registerTaskType(final @NotNull TaskType taskType) {
+        if (!(taskType instanceof final BukkitTaskType bukkitTaskType)) {
+            throw new RuntimeException("BukkitTaskTypeManager implementation can only accept instances of BukkitTaskType!");
+        }
 
         if (super.registerTaskType(taskType)) {
             bukkitTaskType.taskTypeManager = this;
-            plugin.getServer().getPluginManager().registerEvents(bukkitTaskType, plugin);
+            this.plugin.getServer().getPluginManager().registerEvents(bukkitTaskType, this.plugin);
             return true;
         }
+
         return false;
     }
 
-    public void sendDebug(@NotNull String message, @NotNull String taskType, @NotNull String questId, @NotNull String taskId, @NotNull UUID associatedPlayer) {
+    /**
+     * Sends a debug message to players based on their debug preferences.
+     *
+     * @param message the debug message to send
+     * @param taskType the type of task
+     * @param questId the quest ID
+     * @param taskId the task ID
+     * @param associatedPlayer the UUID of the associated player
+     */
+    public void sendDebug(final @NotNull String message, final @NotNull String taskType, final @NotNull String questId, final @NotNull String taskId, final @NotNull UUID associatedPlayer) {
         String chatHeader = null;
-        for (QPlayer qPlayer : plugin.getPlayerManager().getQPlayers()) {
-            QPlayerPreferences.DebugType debugType = qPlayer.getPlayerPreferences().getDebug(questId);
+
+        for (final QPlayer qPlayer : QPlayerPreferences.getDebuggers()) {
+            final QPlayerPreferences.DebugType debugType = qPlayer.getPlayerPreferences().getDebug(questId);
             if (debugType == null) {
                 continue;
             }
 
-            Player player = Bukkit.getPlayer(qPlayer.getPlayerUUID());
+            final Player player = this.plugin.getServer().getPlayer(qPlayer.getPlayerUUID());
             if (player == null) {
                 continue;
             }
 
             if (chatHeader == null) {
-                Player otherPlayer = Bukkit.getPlayer(associatedPlayer);
-                String associatedName = otherPlayer != null ? otherPlayer.getName() : associatedPlayer.toString();
+                final Player otherPlayer = this.plugin.getServer().getPlayer(associatedPlayer);
+                final String associatedName = otherPlayer != null ? otherPlayer.getName() : associatedPlayer.toString();
                 chatHeader = ChatColor.GRAY + "[" + associatedName + " - " + questId + "/" + taskId + " - type '" + taskType + "']";
             }
 
@@ -71,5 +105,4 @@ public class BukkitTaskTypeManager extends TaskTypeManager {
             }
         }
     }
-
 }

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/BukkitTaskTypeManager.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/BukkitTaskTypeManager.java
@@ -45,12 +45,12 @@ public final class BukkitTaskTypeManager extends TaskTypeManager {
      *
      * @param taskType the task type to register
      * @return true if the task type was successfully registered, false otherwise
-     * @throws RuntimeException if the task type is not an instance of {@link BukkitTaskType}
+     * @throws UnsupportedOperationException if the task type is not an instance of {@link BukkitTaskType}
      */
     @Override
     public boolean registerTaskType(final @NotNull TaskType taskType) {
         if (!(taskType instanceof final BukkitTaskType bukkitTaskType)) {
-            throw new RuntimeException("BukkitTaskTypeManager implementation can only accept instances of BukkitTaskType!");
+            throw new UnsupportedOperationException("BukkitTaskTypeManager implementation can only accept instances of BukkitTaskType!");
         }
 
         if (super.registerTaskType(taskType)) {

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/type/BucketEmptyTaskType.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/type/BucketEmptyTaskType.java
@@ -1,44 +1,26 @@
 package com.leonardobishop.quests.bukkit.tasktype.type;
 
 import com.leonardobishop.quests.bukkit.BukkitQuestsPlugin;
-import com.leonardobishop.quests.bukkit.tasktype.BukkitTaskType;
 import com.leonardobishop.quests.bukkit.util.TaskUtils;
-import com.leonardobishop.quests.bukkit.util.constraint.TaskConstraintSet;
-import com.leonardobishop.quests.common.player.QPlayer;
-import com.leonardobishop.quests.common.player.questprogressfile.TaskProgress;
-import com.leonardobishop.quests.common.quest.Quest;
-import com.leonardobishop.quests.common.quest.Task;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.player.PlayerBucketEmptyEvent;
+import org.bukkit.inventory.EquipmentSlot;
+import org.bukkit.inventory.PlayerInventory;
 
-public final class BucketEmptyTaskType extends BukkitTaskType {
-
-    private final BukkitQuestsPlugin plugin;
+public final class BucketEmptyTaskType extends BucketInteractionTaskType {
 
     public BucketEmptyTaskType(BukkitQuestsPlugin plugin) {
-        super("bucketempty", TaskUtils.TASK_ATTRIBUTION_STRING, "Empty a specific bucket.");
-        this.plugin = plugin;
+        super(plugin, "bucketempty", TaskUtils.TASK_ATTRIBUTION_STRING, "Empty a specific bucket.");
     }
 
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onPlayerBucketEmpty(PlayerBucketEmptyEvent event) {
         Player player = event.getPlayer();
-        if (player.hasMetadata("NPC")) {
-            return;
-        }
+        PlayerInventory inventory = player.getInventory();
+        EquipmentSlot slot = event.getHand();
 
-        QPlayer qPlayer = plugin.getPlayerManager().getPlayer(player.getUniqueId());
-        if (qPlayer == null) {
-            return;
-        }
-
-        for (TaskUtils.PendingTask pendingTask : TaskUtils.getApplicableTasks(player, qPlayer, this, TaskConstraintSet.ALL)) {
-            Quest quest = pendingTask.quest();
-            Task task = pendingTask.task();
-            TaskProgress taskProgress = pendingTask.taskProgress();
-
-        }
+        handle(player, inventory.getItem(slot));
     }
 }

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/type/BucketEntityTaskType.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/type/BucketEntityTaskType.java
@@ -1,44 +1,19 @@
 package com.leonardobishop.quests.bukkit.tasktype.type;
 
 import com.leonardobishop.quests.bukkit.BukkitQuestsPlugin;
-import com.leonardobishop.quests.bukkit.tasktype.BukkitTaskType;
 import com.leonardobishop.quests.bukkit.util.TaskUtils;
-import com.leonardobishop.quests.bukkit.util.constraint.TaskConstraintSet;
-import com.leonardobishop.quests.common.player.QPlayer;
-import com.leonardobishop.quests.common.player.questprogressfile.TaskProgress;
-import com.leonardobishop.quests.common.quest.Quest;
-import com.leonardobishop.quests.common.quest.Task;
-import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.player.PlayerBucketEntityEvent;
 
-public final class BucketEntityTaskType extends BukkitTaskType {
-
-    private final BukkitQuestsPlugin plugin;
+public final class BucketEntityTaskType extends BucketInteractionTaskType {
 
     public BucketEntityTaskType(BukkitQuestsPlugin plugin) {
-        super("bucketentity", TaskUtils.TASK_ATTRIBUTION_STRING, "Capture entity with a bucket.");
-        this.plugin = plugin;
+        super(plugin, "bucketentity", TaskUtils.TASK_ATTRIBUTION_STRING, "Capture specific entity in a bucket.");
     }
 
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
-    public void onPlayerBucketEntity(PlayerBucketEntityEvent event) {
-        Player player = event.getPlayer();
-        if (player.hasMetadata("NPC")) {
-            return;
-        }
-
-        QPlayer qPlayer = plugin.getPlayerManager().getPlayer(player.getUniqueId());
-        if (qPlayer == null) {
-            return;
-        }
-
-        for (TaskUtils.PendingTask pendingTask : TaskUtils.getApplicableTasks(player, qPlayer, this, TaskConstraintSet.ALL)) {
-            Quest quest = pendingTask.quest();
-            Task task = pendingTask.task();
-            TaskProgress taskProgress = pendingTask.taskProgress();
-
-        }
+    public void onPlayerBucketEmpty(PlayerBucketEntityEvent event) {
+        handle(event.getPlayer(), event.getEntityBucket());
     }
 }

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/type/BucketEntityTaskType.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/type/BucketEntityTaskType.java
@@ -11,19 +11,19 @@ import com.leonardobishop.quests.common.quest.Task;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
-import org.bukkit.event.player.PlayerBucketEmptyEvent;
+import org.bukkit.event.player.PlayerBucketEntityEvent;
 
-public final class BucketEmptyTaskType extends BukkitTaskType {
+public final class BucketEntityTaskType extends BukkitTaskType {
 
     private final BukkitQuestsPlugin plugin;
 
-    public BucketEmptyTaskType(BukkitQuestsPlugin plugin) {
-        super("bucketempty", TaskUtils.TASK_ATTRIBUTION_STRING, "Empty a specific bucket.");
+    public BucketEntityTaskType(BukkitQuestsPlugin plugin) {
+        super("bucketentity", TaskUtils.TASK_ATTRIBUTION_STRING, "Capture entity with a bucket.");
         this.plugin = plugin;
     }
 
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
-    public void onPlayerBucketEmpty(PlayerBucketEmptyEvent event) {
+    public void onPlayerBucketEntity(PlayerBucketEntityEvent event) {
         Player player = event.getPlayer();
         if (player.hasMetadata("NPC")) {
             return;

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/type/BucketFillTaskType.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/type/BucketFillTaskType.java
@@ -2,47 +2,18 @@ package com.leonardobishop.quests.bukkit.tasktype.type;
 
 import com.leonardobishop.quests.bukkit.BukkitQuestsPlugin;
 import com.leonardobishop.quests.bukkit.util.TaskUtils;
-import com.leonardobishop.quests.bukkit.util.constraint.TaskConstraintSet;
-import com.leonardobishop.quests.common.player.QPlayer;
-import com.leonardobishop.quests.common.player.questprogressfile.TaskProgress;
-import com.leonardobishop.quests.common.quest.Quest;
-import com.leonardobishop.quests.common.quest.Task;
-import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.player.PlayerBucketFillEvent;
 
 public final class BucketFillTaskType extends BucketInteractionTaskType {
 
-    private final BukkitQuestsPlugin plugin;
-
     public BucketFillTaskType(BukkitQuestsPlugin plugin) {
-        super("bucketfill", TaskUtils.TASK_ATTRIBUTION_STRING, "Fill a specific bucket.");
-        this.plugin = plugin;
-
-        super.addConfigValidator(TaskUtils.useRequiredConfigValidator(this, "amount"));
-        super.addConfigValidator(TaskUtils.useIntegerConfigValidator(this, "amount"));
-        super.addConfigValidator(TaskUtils.useRequiredConfigValidator(this, "bucket"));
-        super.addConfigValidator(TaskUtils.useMaterialListConfigValidator(this, TaskUtils.MaterialListConfigValidatorMode.ITEM, "bucket"));
+        super(plugin, "bucketfill", TaskUtils.TASK_ATTRIBUTION_STRING, "Fill a specific bucket.");
     }
 
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onPlayerBucketFill(PlayerBucketFillEvent event) {
-        Player player = event.getPlayer();
-        if (player.hasMetadata("NPC")) {
-            return;
-        }
-
-        QPlayer qPlayer = plugin.getPlayerManager().getPlayer(player.getUniqueId());
-        if (qPlayer == null) {
-            return;
-        }
-
-        for (TaskUtils.PendingTask pendingTask : TaskUtils.getApplicableTasks(player, qPlayer, this, TaskConstraintSet.ALL)) {
-            Quest quest = pendingTask.quest();
-            Task task = pendingTask.task();
-            TaskProgress taskProgress = pendingTask.taskProgress();
-
-        }
+        handle(event.getPlayer(), event.getItemStack());
     }
 }

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/type/BucketFillTaskType.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/type/BucketFillTaskType.java
@@ -2,6 +2,12 @@ package com.leonardobishop.quests.bukkit.tasktype.type;
 
 import com.leonardobishop.quests.bukkit.BukkitQuestsPlugin;
 import com.leonardobishop.quests.bukkit.util.TaskUtils;
+import com.leonardobishop.quests.bukkit.util.constraint.TaskConstraintSet;
+import com.leonardobishop.quests.common.player.QPlayer;
+import com.leonardobishop.quests.common.player.questprogressfile.TaskProgress;
+import com.leonardobishop.quests.common.quest.Quest;
+import com.leonardobishop.quests.common.quest.Task;
+import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.player.PlayerBucketFillEvent;
@@ -13,12 +19,30 @@ public final class BucketFillTaskType extends BucketInteractionTaskType {
     public BucketFillTaskType(BukkitQuestsPlugin plugin) {
         super("bucketfill", TaskUtils.TASK_ATTRIBUTION_STRING, "Fill a specific bucket.");
         this.plugin = plugin;
+
+        super.addConfigValidator(TaskUtils.useRequiredConfigValidator(this, "amount"));
+        super.addConfigValidator(TaskUtils.useIntegerConfigValidator(this, "amount"));
+        super.addConfigValidator(TaskUtils.useRequiredConfigValidator(this, "bucket"));
+        super.addConfigValidator(TaskUtils.useMaterialListConfigValidator(this, TaskUtils.MaterialListConfigValidatorMode.ITEM, "bucket"));
     }
 
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
-    public void onBucketFill(PlayerBucketFillEvent event) {
-        if (event.getItemStack() == null) return;
+    public void onPlayerBucketFill(PlayerBucketFillEvent event) {
+        Player player = event.getPlayer();
+        if (player.hasMetadata("NPC")) {
+            return;
+        }
 
-        super.onBucket(event.getPlayer(), event.getItemStack().getType(), plugin);
+        QPlayer qPlayer = plugin.getPlayerManager().getPlayer(player.getUniqueId());
+        if (qPlayer == null) {
+            return;
+        }
+
+        for (TaskUtils.PendingTask pendingTask : TaskUtils.getApplicableTasks(player, qPlayer, this, TaskConstraintSet.ALL)) {
+            Quest quest = pendingTask.quest();
+            Task task = pendingTask.task();
+            TaskProgress taskProgress = pendingTask.taskProgress();
+
+        }
     }
 }

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/type/BucketInteractionTaskType.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/type/BucketInteractionTaskType.java
@@ -1,6 +1,9 @@
 package com.leonardobishop.quests.bukkit.tasktype.type;
 
+import com.google.common.collect.HashBasedTable;
+import com.google.common.collect.Table;
 import com.leonardobishop.quests.bukkit.BukkitQuestsPlugin;
+import com.leonardobishop.quests.bukkit.item.QuestItem;
 import com.leonardobishop.quests.bukkit.tasktype.BukkitTaskType;
 import com.leonardobishop.quests.bukkit.util.TaskUtils;
 import com.leonardobishop.quests.bukkit.util.constraint.TaskConstraintSet;
@@ -8,22 +11,31 @@ import com.leonardobishop.quests.common.player.QPlayer;
 import com.leonardobishop.quests.common.player.questprogressfile.TaskProgress;
 import com.leonardobishop.quests.common.quest.Quest;
 import com.leonardobishop.quests.common.quest.Task;
-import org.bukkit.Material;
 import org.bukkit.entity.Player;
-import org.jetbrains.annotations.NotNull;
+import org.bukkit.inventory.ItemStack;
 
 public abstract class BucketInteractionTaskType extends BukkitTaskType {
 
-    public BucketInteractionTaskType(@NotNull String type, String author, String description) {
+    private final BukkitQuestsPlugin plugin;
+    private final Table<String, String, QuestItem> fixedQuestItemCache = HashBasedTable.create();
+
+    public BucketInteractionTaskType(BukkitQuestsPlugin plugin, String type, String author, String description) {
         super(type, author, description);
+        this.plugin = plugin;
 
         super.addConfigValidator(TaskUtils.useRequiredConfigValidator(this, "amount"));
         super.addConfigValidator(TaskUtils.useIntegerConfigValidator(this, "amount"));
-        super.addConfigValidator(TaskUtils.useRequiredConfigValidator(this, "bucket"));
-        super.addConfigValidator(TaskUtils.useMaterialListConfigValidator(this, TaskUtils.MaterialListConfigValidatorMode.ITEM, "bucket"));
+        super.addConfigValidator(TaskUtils.useItemStackConfigValidator(this, "bucket"));
+        super.addConfigValidator(TaskUtils.useIntegerConfigValidator(this, "data"));
+        super.addConfigValidator(TaskUtils.useBooleanConfigValidator(this, "exact-match"));
     }
 
-    public void onBucket(Player player, Material bucket, BukkitQuestsPlugin plugin) {
+    @Override
+    public void onReady() {
+        fixedQuestItemCache.clear();
+    }
+
+    protected void handle(Player player, ItemStack item) {
         if (player.hasMetadata("NPC")) {
             return;
         }
@@ -38,21 +50,28 @@ public abstract class BucketInteractionTaskType extends BukkitTaskType {
             Task task = pendingTask.task();
             TaskProgress taskProgress = pendingTask.taskProgress();
 
-            int amount = (int) task.getConfigValue("amount");
-            Object configBucket = task.getConfigValue("bucket");
-            Material material = Material.getMaterial((String) configBucket);
+            if (task.hasConfigKey("bucket")) {
+                QuestItem qi;
+                if ((qi = fixedQuestItemCache.get(quest.getId(), task.getId())) == null) {
+                    QuestItem fetchedItem = TaskUtils.getConfigQuestItem(task, "bucket", "data");
+                    fixedQuestItemCache.put(quest.getId(), task.getId(), fetchedItem);
+                    qi = fetchedItem;
+                }
 
-            super.debug("Player used bucket of type " + bucket, quest.getId(), task.getId(), player.getUniqueId());
+                super.debug("Player interacted with bucket of type " + item.getType(), quest.getId(), task.getId(), player.getUniqueId());
 
-            if (bucket != material) {
-                super.debug("Player bucket does not match required bucket '" + material + "', continuing...", quest.getId(), task.getId(), player.getUniqueId());
-                continue;
+                boolean exactMatch = TaskUtils.getConfigBoolean(task, "exact-match", true);
+                if (!qi.compareItemStack(item, exactMatch)) {
+                    super.debug("Item does not match, continuing...", quest.getId(), task.getId(), player.getUniqueId());
+                    continue;
+                }
             }
 
             int progress = TaskUtils.incrementIntegerTaskProgress(taskProgress);
             super.debug("Incrementing task progress (now " + progress + ")", quest.getId(), task.getId(), player.getUniqueId());
 
-            if ((int) taskProgress.getProgress() >= amount) {
+            int amount = (int) task.getConfigValue("amount");
+            if (progress >= amount) {
                 super.debug("Marking task as complete", quest.getId(), task.getId(), player.getUniqueId());
                 taskProgress.setCompleted(true);
             }

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/type/CuringTaskType.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/type/CuringTaskType.java
@@ -11,6 +11,7 @@ import com.leonardobishop.quests.common.quest.Task;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
+import org.bukkit.entity.Villager;
 import org.bukkit.entity.ZombieVillager;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -54,12 +55,20 @@ public final class CuringTaskType extends BukkitTaskType {
             return;
         }
 
+        Villager.Type type = zombieVillager.getVillagerType();
+        Villager.Profession profession = zombieVillager.getVillagerProfession();
+
         for (TaskUtils.PendingTask pendingTask : TaskUtils.getApplicableTasks(player, qPlayer, this, TaskConstraintSet.ALL)) {
             Quest quest = pendingTask.quest();
             Task task = pendingTask.task();
             TaskProgress taskProgress = pendingTask.taskProgress();
 
-            super.debug("Player cured " + entity.getType(), quest.getId(), task.getId(), player.getUniqueId());
+            // I don't know why my IDE thinks profession
+            // is always null, probably a bad API design.
+            //noinspection ConstantValue
+            super.debug("Player cured " + zombieVillager.getType() + " of profession " + profession + " and type " + type, quest.getId(), task.getId(), player.getUniqueId());
+
+            // TODO: add villager-type and villager-profession options
 
             int progress = TaskUtils.incrementIntegerTaskProgress(taskProgress);
             super.debug("Incrementing task progress (now " + progress + ")", quest.getId(), task.getId(), player.getUniqueId());

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/type/CuringTaskType.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/type/CuringTaskType.java
@@ -1,6 +1,5 @@
 package com.leonardobishop.quests.bukkit.tasktype.type;
 
-import com.destroystokyo.paper.event.entity.ThrownEggHatchEvent;
 import com.leonardobishop.quests.bukkit.BukkitQuestsPlugin;
 import com.leonardobishop.quests.bukkit.tasktype.BukkitTaskType;
 import com.leonardobishop.quests.bukkit.util.TaskUtils;
@@ -9,34 +8,40 @@ import com.leonardobishop.quests.common.player.QPlayer;
 import com.leonardobishop.quests.common.player.questprogressfile.TaskProgress;
 import com.leonardobishop.quests.common.quest.Quest;
 import com.leonardobishop.quests.common.quest.Task;
-import org.bukkit.entity.EntityType;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
+import org.bukkit.entity.ZombieVillager;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
-import org.bukkit.projectiles.ProjectileSource;
+import org.bukkit.event.entity.EntityTransformEvent;
 
-public final class HatchingTaskType extends BukkitTaskType {
+public final class CuringTaskType extends BukkitTaskType {
 
     private final BukkitQuestsPlugin plugin;
 
-    public HatchingTaskType(BukkitQuestsPlugin plugin) {
-        super("hatching", TaskUtils.TASK_ATTRIBUTION_STRING, "Hatch a set amount of entities of certain types.");
+    public CuringTaskType(BukkitQuestsPlugin plugin) {
+        super("curing", TaskUtils.TASK_ATTRIBUTION_STRING, "Cure a set amount of zombie villagers.");
         this.plugin = plugin;
 
         super.addConfigValidator(TaskUtils.useRequiredConfigValidator(this, "amount"));
         super.addConfigValidator(TaskUtils.useIntegerConfigValidator(this, "amount"));
-        super.addConfigValidator(TaskUtils.useEntityListConfigValidator(this, "mob", "mobs"));
     }
 
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
-    public void onThrownEggHatch(ThrownEggHatchEvent event) {
-        int numHatches = event.getNumHatches();
-        if (numHatches == 0) {
+    public void onEntityTransform(EntityTransformEvent event) {
+        EntityTransformEvent.TransformReason reason = event.getTransformReason();
+        if (reason != EntityTransformEvent.TransformReason.CURED) {
             return;
         }
 
-        ProjectileSource shooter = event.getEgg().getShooter();
-        if (!(shooter instanceof Player player)) {
+        Entity entity = event.getEntity();
+        if (!(entity instanceof ZombieVillager zombieVillager)) {
+            return;
+        }
+
+        OfflinePlayer offlinePlayer = zombieVillager.getConversionPlayer();
+        if (!(offlinePlayer instanceof Player player)) {
             return;
         }
 
@@ -49,21 +54,14 @@ public final class HatchingTaskType extends BukkitTaskType {
             return;
         }
 
-        EntityType hatchingType = event.getHatchingType();
-
         for (TaskUtils.PendingTask pendingTask : TaskUtils.getApplicableTasks(player, qPlayer, this, TaskConstraintSet.ALL)) {
             Quest quest = pendingTask.quest();
             Task task = pendingTask.task();
             TaskProgress taskProgress = pendingTask.taskProgress();
 
-            super.debug("Player hatched " + hatchingType, quest.getId(), task.getId(), player.getUniqueId());
+            super.debug("Player cured " + entity.getType(), quest.getId(), task.getId(), player.getUniqueId());
 
-            if (!TaskUtils.matchEntity(this, pendingTask, hatchingType, player.getUniqueId())) {
-                super.debug("Continuing...", quest.getId(), task.getId(), player.getUniqueId());
-                continue;
-            }
-
-            int progress = TaskUtils.incrementIntegerTaskProgress(taskProgress, numHatches);
+            int progress = TaskUtils.incrementIntegerTaskProgress(taskProgress);
             super.debug("Incrementing task progress (now " + progress + ")", quest.getId(), task.getId(), player.getUniqueId());
 
             int amount = (int) task.getConfigValue("amount");

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/type/CuringTaskType.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/type/CuringTaskType.java
@@ -65,6 +65,10 @@ public final class CuringTaskType extends BukkitTaskType {
 
             // I don't know why my IDE thinks profession
             // is always null, probably a bad API design.
+            //
+            // Yeah, ZombieVillager is missing an override
+            // for annotation from the Zombie interface.
+            //
             //noinspection ConstantValue
             super.debug("Player cured " + zombieVillager.getType() + " of profession " + profession + " and type " + type, quest.getId(), task.getId(), player.getUniqueId());
 

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/type/ItembreakingTaskType.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/type/ItembreakingTaskType.java
@@ -1,0 +1,90 @@
+package com.leonardobishop.quests.bukkit.tasktype.type;
+
+import com.google.common.collect.HashBasedTable;
+import com.google.common.collect.Table;
+import com.leonardobishop.quests.bukkit.BukkitQuestsPlugin;
+import com.leonardobishop.quests.bukkit.item.QuestItem;
+import com.leonardobishop.quests.bukkit.tasktype.BukkitTaskType;
+import com.leonardobishop.quests.bukkit.util.TaskUtils;
+import com.leonardobishop.quests.bukkit.util.constraint.TaskConstraintSet;
+import com.leonardobishop.quests.common.player.QPlayer;
+import com.leonardobishop.quests.common.player.questprogressfile.TaskProgress;
+import com.leonardobishop.quests.common.quest.Quest;
+import com.leonardobishop.quests.common.quest.Task;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.player.PlayerItemBreakEvent;
+import org.bukkit.inventory.ItemStack;
+
+public final class ItembreakingTaskType extends BukkitTaskType {
+
+    private final BukkitQuestsPlugin plugin;
+    private final Table<String, String, QuestItem> fixedQuestItemCache = HashBasedTable.create();
+
+    public ItembreakingTaskType(BukkitQuestsPlugin plugin) {
+        super("itembreaking", TaskUtils.TASK_ATTRIBUTION_STRING, "Break a set amount of certain items.");
+        this.plugin = plugin;
+
+        super.addConfigValidator(TaskUtils.useRequiredConfigValidator(this, "amount"));
+        super.addConfigValidator(TaskUtils.useIntegerConfigValidator(this, "amount"));
+        super.addConfigValidator(TaskUtils.useItemStackConfigValidator(this, "item"));
+        super.addConfigValidator(TaskUtils.useIntegerConfigValidator(this, "data"));
+        super.addConfigValidator(TaskUtils.useBooleanConfigValidator(this, "exact-match"));
+    }
+
+    @Override
+    public void onReady() {
+        fixedQuestItemCache.clear();
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onPlayerItemBreak(PlayerItemBreakEvent event) {
+        Player player = event.getPlayer();
+        if (player.hasMetadata("NPC")) {
+            return;
+        }
+
+        QPlayer qPlayer = plugin.getPlayerManager().getPlayer(player.getUniqueId());
+        if (qPlayer == null) {
+            return;
+        }
+
+        ItemStack item = event.getBrokenItem();
+
+        for (TaskUtils.PendingTask pendingTask : TaskUtils.getApplicableTasks(player, qPlayer, this, TaskConstraintSet.ALL)) {
+            Quest quest = pendingTask.quest();
+            Task task = pendingTask.task();
+            TaskProgress taskProgress = pendingTask.taskProgress();
+
+            if (task.hasConfigKey("item")) {
+                QuestItem qi;
+                if ((qi = fixedQuestItemCache.get(quest.getId(), task.getId())) == null) {
+                    QuestItem fetchedItem = TaskUtils.getConfigQuestItem(task, "item", "data");
+                    fixedQuestItemCache.put(quest.getId(), task.getId(), fetchedItem);
+                    qi = fetchedItem;
+                }
+
+                super.debug("Player broke item of type " + item.getType(), quest.getId(), task.getId(), player.getUniqueId());
+
+                boolean exactMatch = TaskUtils.getConfigBoolean(task, "exact-match", true);
+                if (!qi.compareItemStack(item, exactMatch)) {
+                    super.debug("Item does not match required item, continuing...", quest.getId(), task.getId(), player.getUniqueId());
+                    continue;
+                }
+            }
+
+            int progress = TaskUtils.incrementIntegerTaskProgress(taskProgress);
+            super.debug("Incrementing task progress (now " + progress + ")", quest.getId(), task.getId(), player.getUniqueId());
+
+            int amount = (int) task.getConfigValue("amount");
+
+            if (progress >= amount) {
+                super.debug("Marking task as complete", quest.getId(), task.getId(), player.getUniqueId());
+                taskProgress.setCompleted(true);
+            }
+
+            TaskUtils.sendTrackAdvancement(player, quest, task, pendingTask, amount);
+        }
+    }
+}

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/type/ItemdamagingTaskType.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/type/ItemdamagingTaskType.java
@@ -1,0 +1,91 @@
+package com.leonardobishop.quests.bukkit.tasktype.type;
+
+import com.google.common.collect.HashBasedTable;
+import com.google.common.collect.Table;
+import com.leonardobishop.quests.bukkit.BukkitQuestsPlugin;
+import com.leonardobishop.quests.bukkit.item.QuestItem;
+import com.leonardobishop.quests.bukkit.tasktype.BukkitTaskType;
+import com.leonardobishop.quests.bukkit.util.TaskUtils;
+import com.leonardobishop.quests.bukkit.util.constraint.TaskConstraintSet;
+import com.leonardobishop.quests.common.player.QPlayer;
+import com.leonardobishop.quests.common.player.questprogressfile.TaskProgress;
+import com.leonardobishop.quests.common.quest.Quest;
+import com.leonardobishop.quests.common.quest.Task;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.player.PlayerItemDamageEvent;
+import org.bukkit.inventory.ItemStack;
+
+public final class ItemdamagingTaskType extends BukkitTaskType {
+
+    private final BukkitQuestsPlugin plugin;
+    private final Table<String, String, QuestItem> fixedQuestItemCache = HashBasedTable.create();
+
+    public ItemdamagingTaskType(BukkitQuestsPlugin plugin) {
+        super("itemdamaging", TaskUtils.TASK_ATTRIBUTION_STRING, "Damage certain items with a set amount of damage.");
+        this.plugin = plugin;
+
+        super.addConfigValidator(TaskUtils.useRequiredConfigValidator(this, "amount"));
+        super.addConfigValidator(TaskUtils.useIntegerConfigValidator(this, "amount"));
+        super.addConfigValidator(TaskUtils.useItemStackConfigValidator(this, "item"));
+        super.addConfigValidator(TaskUtils.useIntegerConfigValidator(this, "data"));
+        super.addConfigValidator(TaskUtils.useBooleanConfigValidator(this, "exact-match"));
+    }
+
+    @Override
+    public void onReady() {
+        fixedQuestItemCache.clear();
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onPlayerItemDamage(PlayerItemDamageEvent event) {
+        Player player = event.getPlayer();
+        if (player.hasMetadata("NPC")) {
+            return;
+        }
+
+        QPlayer qPlayer = plugin.getPlayerManager().getPlayer(player.getUniqueId());
+        if (qPlayer == null) {
+            return;
+        }
+
+        ItemStack item = event.getItem();
+        int damage = event.getDamage();
+
+        for (TaskUtils.PendingTask pendingTask : TaskUtils.getApplicableTasks(player, qPlayer, this, TaskConstraintSet.ALL)) {
+            Quest quest = pendingTask.quest();
+            Task task = pendingTask.task();
+            TaskProgress taskProgress = pendingTask.taskProgress();
+
+            if (task.hasConfigKey("item")) {
+                QuestItem qi;
+                if ((qi = fixedQuestItemCache.get(quest.getId(), task.getId())) == null) {
+                    QuestItem fetchedItem = TaskUtils.getConfigQuestItem(task, "item", "data");
+                    fixedQuestItemCache.put(quest.getId(), task.getId(), fetchedItem);
+                    qi = fetchedItem;
+                }
+
+                super.debug("Player damaged item of type " + item.getType(), quest.getId(), task.getId(), player.getUniqueId());
+
+                boolean exactMatch = TaskUtils.getConfigBoolean(task, "exact-match", true);
+                if (!qi.compareItemStack(item, exactMatch)) {
+                    super.debug("Item does not match required item, continuing...", quest.getId(), task.getId(), player.getUniqueId());
+                    continue;
+                }
+            }
+
+            int progress = TaskUtils.incrementIntegerTaskProgress(taskProgress, damage);
+            super.debug("Incrementing task progress (now " + progress + ")", quest.getId(), task.getId(), player.getUniqueId());
+
+            int amount = (int) task.getConfigValue("amount");
+
+            if (progress >= amount) {
+                super.debug("Marking task as complete", quest.getId(), task.getId(), player.getUniqueId());
+                taskProgress.setCompleted(true);
+            }
+
+            TaskUtils.sendTrackAdvancement(player, quest, task, pendingTask, amount);
+        }
+    }
+}

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/type/ItemmendingTaskType.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/type/ItemmendingTaskType.java
@@ -1,0 +1,91 @@
+package com.leonardobishop.quests.bukkit.tasktype.type;
+
+import com.google.common.collect.HashBasedTable;
+import com.google.common.collect.Table;
+import com.leonardobishop.quests.bukkit.BukkitQuestsPlugin;
+import com.leonardobishop.quests.bukkit.item.QuestItem;
+import com.leonardobishop.quests.bukkit.tasktype.BukkitTaskType;
+import com.leonardobishop.quests.bukkit.util.TaskUtils;
+import com.leonardobishop.quests.bukkit.util.constraint.TaskConstraintSet;
+import com.leonardobishop.quests.common.player.QPlayer;
+import com.leonardobishop.quests.common.player.questprogressfile.TaskProgress;
+import com.leonardobishop.quests.common.quest.Quest;
+import com.leonardobishop.quests.common.quest.Task;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.player.PlayerItemMendEvent;
+import org.bukkit.inventory.ItemStack;
+
+public final class ItemmendingTaskType extends BukkitTaskType {
+
+    private final BukkitQuestsPlugin plugin;
+    private final Table<String, String, QuestItem> fixedQuestItemCache = HashBasedTable.create();
+
+    public ItemmendingTaskType(BukkitQuestsPlugin plugin) {
+        super("itemmending", TaskUtils.TASK_ATTRIBUTION_STRING, "Mend certain items with a set amount of repair.");
+        this.plugin = plugin;
+
+        super.addConfigValidator(TaskUtils.useRequiredConfigValidator(this, "amount"));
+        super.addConfigValidator(TaskUtils.useIntegerConfigValidator(this, "amount"));
+        super.addConfigValidator(TaskUtils.useItemStackConfigValidator(this, "item"));
+        super.addConfigValidator(TaskUtils.useIntegerConfigValidator(this, "data"));
+        super.addConfigValidator(TaskUtils.useBooleanConfigValidator(this, "exact-match"));
+    }
+
+    @Override
+    public void onReady() {
+        fixedQuestItemCache.clear();
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onPlayerItemDamage(PlayerItemMendEvent event) {
+        Player player = event.getPlayer();
+        if (player.hasMetadata("NPC")) {
+            return;
+        }
+
+        QPlayer qPlayer = plugin.getPlayerManager().getPlayer(player.getUniqueId());
+        if (qPlayer == null) {
+            return;
+        }
+
+        ItemStack item = event.getItem();
+        int repairAmount = event.getRepairAmount();
+
+        for (TaskUtils.PendingTask pendingTask : TaskUtils.getApplicableTasks(player, qPlayer, this, TaskConstraintSet.ALL)) {
+            Quest quest = pendingTask.quest();
+            Task task = pendingTask.task();
+            TaskProgress taskProgress = pendingTask.taskProgress();
+
+            if (task.hasConfigKey("item")) {
+                QuestItem qi;
+                if ((qi = fixedQuestItemCache.get(quest.getId(), task.getId())) == null) {
+                    QuestItem fetchedItem = TaskUtils.getConfigQuestItem(task, "item", "data");
+                    fixedQuestItemCache.put(quest.getId(), task.getId(), fetchedItem);
+                    qi = fetchedItem;
+                }
+
+                super.debug("Player mended item of type " + item.getType(), quest.getId(), task.getId(), player.getUniqueId());
+
+                boolean exactMatch = TaskUtils.getConfigBoolean(task, "exact-match", true);
+                if (!qi.compareItemStack(item, exactMatch)) {
+                    super.debug("Item does not match required item, continuing...", quest.getId(), task.getId(), player.getUniqueId());
+                    continue;
+                }
+            }
+
+            int progress = TaskUtils.incrementIntegerTaskProgress(taskProgress, repairAmount);
+            super.debug("Incrementing task progress (now " + progress + ")", quest.getId(), task.getId(), player.getUniqueId());
+
+            int amount = (int) task.getConfigValue("amount");
+
+            if (progress >= amount) {
+                super.debug("Marking task as complete", quest.getId(), task.getId(), player.getUniqueId());
+                taskProgress.setCompleted(true);
+            }
+
+            TaskUtils.sendTrackAdvancement(player, quest, task, pendingTask, amount);
+        }
+    }
+}

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/type/ResurrectingTaskType.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/type/ResurrectingTaskType.java
@@ -1,0 +1,65 @@
+package com.leonardobishop.quests.bukkit.tasktype.type;
+
+import com.leonardobishop.quests.bukkit.BukkitQuestsPlugin;
+import com.leonardobishop.quests.bukkit.tasktype.BukkitTaskType;
+import com.leonardobishop.quests.bukkit.util.TaskUtils;
+import com.leonardobishop.quests.bukkit.util.constraint.TaskConstraintSet;
+import com.leonardobishop.quests.common.player.QPlayer;
+import com.leonardobishop.quests.common.player.questprogressfile.TaskProgress;
+import com.leonardobishop.quests.common.quest.Quest;
+import com.leonardobishop.quests.common.quest.Task;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.entity.EntityResurrectEvent;
+
+public final class ResurrectingTaskType extends BukkitTaskType {
+
+    private final BukkitQuestsPlugin plugin;
+
+    public ResurrectingTaskType(BukkitQuestsPlugin plugin) {
+        super("resurrecting", TaskUtils.TASK_ATTRIBUTION_STRING, "Resurrect a set amount of times.");
+        this.plugin = plugin;
+
+        super.addConfigValidator(TaskUtils.useRequiredConfigValidator(this, "amount"));
+        super.addConfigValidator(TaskUtils.useIntegerConfigValidator(this, "amount"));
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onEntityResurrect(EntityResurrectEvent event) {
+        LivingEntity entity = event.getEntity();
+        if (!(entity instanceof Player player)) {
+            return;
+        }
+
+        if (player.hasMetadata("NPC")) {
+            return;
+        }
+
+        QPlayer qPlayer = plugin.getPlayerManager().getPlayer(player.getUniqueId());
+        if (qPlayer == null) {
+            return;
+        }
+
+        for (TaskUtils.PendingTask pendingTask : TaskUtils.getApplicableTasks(player, qPlayer, this, TaskConstraintSet.ALL)) {
+            Quest quest = pendingTask.quest();
+            Task task = pendingTask.task();
+            TaskProgress taskProgress = pendingTask.taskProgress();
+
+            super.debug("Player resurrected", quest.getId(), task.getId(), player.getUniqueId());
+
+            int progress = TaskUtils.incrementIntegerTaskProgress(taskProgress);
+            super.debug("Incrementing task progress (now " + progress + ")", quest.getId(), task.getId(), player.getUniqueId());
+
+            int amount = (int) task.getConfigValue("amount");
+
+            if (progress >= amount) {
+                super.debug("Marking task as complete", quest.getId(), task.getId(), player.getUniqueId());
+                taskProgress.setCompleted(true);
+            }
+
+            TaskUtils.sendTrackAdvancement(player, quest, task, pendingTask, amount);
+        }
+    }
+}

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/type/SmeltingTaskType.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/type/SmeltingTaskType.java
@@ -25,6 +25,9 @@ import org.bukkit.inventory.ItemStack;
 
 import java.math.RoundingMode;
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
 
 public final class SmeltingTaskType extends BukkitTaskType {
 
@@ -91,6 +94,7 @@ public final class SmeltingTaskType extends BukkitTaskType {
         }
 
         final InventoryType inventoryType = event.getInventory().getType();
+        final String inventoryTypeName = inventoryTypeNames.get(inventoryType);
 
         for (TaskUtils.PendingTask pendingTask : TaskUtils.getApplicableTasks(player, qPlayer, this, TaskConstraintSet.ALL)) {
             Quest quest = pendingTask.quest();
@@ -98,7 +102,7 @@ public final class SmeltingTaskType extends BukkitTaskType {
             TaskProgress taskProgress = pendingTask.taskProgress();
 
             String mode = (String) task.getConfigValue("mode");
-            if (mode != null && !inventoryType.name().equalsIgnoreCase(mode)) {
+            if (mode != null && !inventoryTypeName.equals(mode)) {
                 super.debug("Specific mode is required, but the actual mode '" + inventoryType + "' does not match, continuing...", quest.getId(), task.getId(), player.getUniqueId());
                 continue;
             }
@@ -134,4 +138,12 @@ public final class SmeltingTaskType extends BukkitTaskType {
             TaskUtils.sendTrackAdvancement(player, quest, task, pendingTask, amount);
         }
     }
+
+    private static final Map<InventoryType, String> inventoryTypeNames = new HashMap<>() {{
+        for (final InventoryType inventoryType : InventoryType.values()) {
+            final String name = inventoryType.name();
+            final String nameLowerCase = name.toLowerCase(Locale.ROOT);
+            this.put(inventoryType, nameLowerCase);
+        }
+    }};
 }

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/type/dependent/EssentialsBalanceTaskType.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/type/dependent/EssentialsBalanceTaskType.java
@@ -15,6 +15,7 @@ import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
+import org.jetbrains.annotations.NotNull;
 
 import java.math.BigDecimal;
 import java.util.UUID;
@@ -32,7 +33,7 @@ public final class EssentialsBalanceTaskType extends BukkitTaskType {
     }
 
     @Override
-    public void onStart(Quest quest, Task task, UUID playerUUID) {
+    public void onStart(final @NotNull Quest quest, final @NotNull Task task, final @NotNull UUID playerUUID) {
         Player player = Bukkit.getPlayer(playerUUID);
         if (player == null || !player.isOnline() || player.hasMetadata("NPC")) {
             return;

--- a/bukkit/src/main/resources/plugin.yml
+++ b/bukkit/src/main/resources/plugin.yml
@@ -19,6 +19,7 @@ softdepend:
 - FabledSkyBlock
 - IridiumSkyblock
 - MythicMobs
+- Oraxen
 - PinataParty
 - PlaceholderAPI
 - PlayerBlockTracker

--- a/common/src/main/java/com/leonardobishop/quests/common/player/QPlayerPreferences.java
+++ b/common/src/main/java/com/leonardobishop/quests/common/player/QPlayerPreferences.java
@@ -1,37 +1,59 @@
 package com.leonardobishop.quests.common.player;
 
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
+import java.util.WeakHashMap;
 
-public class QPlayerPreferences {
+public final class QPlayerPreferences {
+
+    private static Set<QPlayer> debuggers = Collections.newSetFromMap(new WeakHashMap<>());
 
     private final Map<String, DebugType> debug = new HashMap<>();
     private String trackedQuestId;
 
-    public QPlayerPreferences(String trackedQuestId) {
+    public QPlayerPreferences(final @Nullable String trackedQuestId) {
         this.trackedQuestId = trackedQuestId;
     }
 
     public @Nullable String getTrackedQuestId() {
-        return trackedQuestId;
+        return this.trackedQuestId;
     }
 
-    public void setTrackedQuestId(@Nullable String trackedQuestId) {
+    public void setTrackedQuestId(final @Nullable String trackedQuestId) {
         this.trackedQuestId = trackedQuestId;
     }
 
-    public DebugType getDebug(String questId) {
-        return debug.getOrDefault(questId, debug.get("*"));
+    public @Nullable DebugType getDebug(final @NotNull String questId) {
+        return this.debug.getOrDefault(questId, this.debug.get("*"));
     }
 
-    public void setDebug(String questId, DebugType debugType) {
-        debug.put(questId, debugType);
+    public void setDebug(final @NotNull String questId, final @NotNull DebugType debugType) {
+        this.debug.put(questId, debugType);
+    }
+
+    public void unsetDebug(final @NotNull String questId) {
+        this.debug.remove(questId);
+    }
+
+    public boolean isDebug() {
+        return !this.debug.isEmpty();
     }
 
     public enum DebugType {
         SELF,
         ALL
+    }
+
+    public static @NotNull Set<QPlayer> getDebuggers() {
+        return QPlayerPreferences.debuggers;
+    }
+
+    public static void setDebuggers(final @NotNull Set<QPlayer> debuggers) {
+        QPlayerPreferences.debuggers = debuggers;
     }
 }

--- a/common/src/main/java/com/leonardobishop/quests/common/player/questprogressfile/QuestProgressFile.java
+++ b/common/src/main/java/com/leonardobishop/quests/common/player/questprogressfile/QuestProgressFile.java
@@ -26,7 +26,7 @@ public class QuestProgressFile {
         Class<?> optimizedMapClazz;
 
         try {
-            optimizedMapClazz = Class.forName("it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap");
+            optimizedMapClazz = Class.forName("it.unimi.dsi.fastutil.objects.Object2ObjectArrayMap");
         } catch (ClassNotFoundException ignored) {
             optimizedMapClazz = HashMap.class;
         }

--- a/common/src/main/java/com/leonardobishop/quests/common/player/questprogressfile/QuestProgressFile.java
+++ b/common/src/main/java/com/leonardobishop/quests/common/player/questprogressfile/QuestProgressFile.java
@@ -308,7 +308,7 @@ public class QuestProgressFile {
     @Deprecated
     public void clean() {
         plugin.getQuestsLogger().debug("Cleaning file " + playerUUID + ".");
-        if (!plugin.getTaskTypeManager().areRegistrationsAccepted()) {
+        if (!plugin.getTaskTypeManager().areRegistrationsOpen()) {
             ArrayList<String> invalidQuests = new ArrayList<>();
             for (String questId : this.questProgress.keySet()) {
                 Quest q;

--- a/common/src/main/java/com/leonardobishop/quests/common/quest/Quest.java
+++ b/common/src/main/java/com/leonardobishop/quests/common/quest/Quest.java
@@ -20,6 +20,8 @@ public class Quest implements Comparable<Quest> {
     private List<String> requirements;
     private List<String> rewardString;
     private List<String> startString;
+    private List<String> cancelString;
+    private List<String> expiryString;
     private List<String> startCommands;
     private List<String> cancelCommands;
     private List<String> expiryCommands;
@@ -121,6 +123,26 @@ public class Quest implements Comparable<Quest> {
      */
     public @NotNull List<String> getStartString() {
         return Collections.unmodifiableList(startString);
+    }
+
+    /**
+     * Get the cancel string of the quest.
+     * The cancel string is a series of messages sent to the player upon cancelling the quest.
+     *
+     * @return immutable list of messages to send
+     */
+    public @NotNull List<String> getCancelString() {
+        return Collections.unmodifiableList(cancelString);
+    }
+
+    /**
+     * Get the expiry string of the quest.
+     * The expiry string is a series of messages sent to the player upon expiring the quest.
+     *
+     * @return immutable list of messages to send
+     */
+    public @NotNull List<String> getExpiryString() {
+        return Collections.unmodifiableList(expiryString);
     }
 
     /**
@@ -315,6 +337,8 @@ public class Quest implements Comparable<Quest> {
         private List<String> requirements = Collections.emptyList();
         private List<String> rewardString = Collections.emptyList();
         private List<String> startString = Collections.emptyList();
+        private List<String> cancelString = Collections.emptyList();
+        private List<String> expiryString = Collections.emptyList();
         private List<String> startCommands = Collections.emptyList();
         private List<String> cancelCommands = Collections.emptyList();
         private List<String> expiryCommands = Collections.emptyList();
@@ -353,6 +377,16 @@ public class Quest implements Comparable<Quest> {
 
         public Builder withStartString(List<String> startString) {
             this.startString = startString;
+            return this;
+        }
+
+        public Builder withCancelString(List<String> cancelString) {
+            this.cancelString = cancelString;
+            return this;
+        }
+
+        public Builder withExpiryString(List<String> expiryString) {
+            this.expiryString = expiryString;
             return this;
         }
 
@@ -443,6 +477,8 @@ public class Quest implements Comparable<Quest> {
             quest.requirements = this.requirements;
             quest.rewardString = this.rewardString;
             quest.startString = this.startString;
+            quest.cancelString = this.cancelString;
+            quest.expiryString = this.expiryString;
             quest.startCommands = this.startCommands;
             quest.cancelCommands = this.cancelCommands;
             quest.expiryCommands = this.expiryCommands;
@@ -459,9 +495,7 @@ public class Quest implements Comparable<Quest> {
             quest.placeholders = this.placeholders;
             quest.progressPlaceholders = this.progressPlaceholders;
             quest.categoryid = this.categoryid;
-
             return quest;
         }
-
     }
 }

--- a/common/src/main/java/com/leonardobishop/quests/common/tasktype/TaskType.java
+++ b/common/src/main/java/com/leonardobishop/quests/common/tasktype/TaskType.java
@@ -49,6 +49,17 @@ public abstract class TaskType {
     }
 
     /**
+     * Constructs a TaskType with the specified type, author, and description.
+     *
+     * @param type the name of the task type, should not contain spaces
+     * @param author the name of the person (or people) who wrote it
+     * @param description a short, simple description of the task type
+     */
+    public TaskType(final @NotNull String type, final @Nullable String author, final @Nullable String description) {
+        this(type, author, description, new String[0]);
+    }
+
+    /**
      * Constructs a TaskType with the specified type.
      *
      * @param type the name of the task type, should not contain spaces

--- a/common/src/main/java/com/leonardobishop/quests/common/tasktype/TaskTypeManager.java
+++ b/common/src/main/java/com/leonardobishop/quests/common/tasktype/TaskTypeManager.java
@@ -25,6 +25,7 @@ public abstract class TaskTypeManager {
     private final Map<String, TaskType> taskTypes = new HashMap<>();
     private final Map<String, String> aliases = new HashMap<>();
     private final Set<String> exclusions;
+    private int registered;
     private int skipped;
     private int unsupported;
     private boolean registrationsOpen;
@@ -102,6 +103,7 @@ public abstract class TaskTypeManager {
             this.aliases.put(alias, type);
         }
 
+        this.registered++;
         return true;
     }
 
@@ -193,6 +195,15 @@ public abstract class TaskTypeManager {
      */
     public @NotNull Set<String> getExclusions() {
         return Collections.unmodifiableSet(this.exclusions);
+    }
+
+    /**
+     * Returns the number of task types registered.
+     *
+     * @return number of task types registered
+     */
+    public int getRegistered() {
+        return this.registered;
     }
 
     /**

--- a/common/src/main/java/com/leonardobishop/quests/common/tasktype/TaskTypeManager.java
+++ b/common/src/main/java/com/leonardobishop/quests/common/tasktype/TaskTypeManager.java
@@ -5,11 +5,9 @@ import com.leonardobishop.quests.common.quest.Task;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -21,162 +19,197 @@ import java.util.function.Supplier;
  * Task types can only be registered if registrations are enabled, which is typically only during start-up.
  * This is to ensure quests are only registered to task types when all task types have been registered first.
  */
+@SuppressWarnings("UnusedReturnValue")
 public abstract class TaskTypeManager {
 
     private final Map<String, TaskType> taskTypes = new HashMap<>();
     private final Map<String, String> aliases = new HashMap<>();
-    private final List<String> exclusions;
+    private final Set<String> exclusions;
     private int skipped;
-    private boolean allowRegistrations;
+    private int unsupported;
+    private boolean registrationsOpen;
 
     public TaskTypeManager() {
-        allowRegistrations = true;
-        exclusions = new ArrayList<>();
+        this.registrationsOpen = true;
+        this.exclusions = Collections.emptySet();
     }
 
-    public TaskTypeManager(List<String> exclusions) {
-        allowRegistrations = true;
+    public TaskTypeManager(final @NotNull Set<String> exclusions) {
+        this.registrationsOpen = true;
         this.exclusions = exclusions;
     }
 
+    /**
+     * Closes the task type registrations. This is typically done after start-up.
+     */
     public void closeRegistrations() {
-        allowRegistrations = false;
-    }
-
-    public boolean areRegistrationsAccepted() {
-        return allowRegistrations;
+        this.registrationsOpen = false;
     }
 
     /**
+     * Checks if registrations are still open.
+     *
+     * @return true if registrations are open, false otherwise
+     */
+    public boolean areRegistrationsOpen() {
+        return this.registrationsOpen;
+    }
+
+    /**
+     * Returns an immutable collection containing all registered task types.
+     *
      * @return immutable {@link Set} containing all registered {@link TaskType}
      */
     public @NotNull Collection<TaskType> getTaskTypes() {
-        return Collections.unmodifiableCollection(taskTypes.values());
+        return Collections.unmodifiableCollection(this.taskTypes.values());
     }
 
     /**
      * Resets all quest to task type registrations. This does not clear the task types registered to the task type manager.
      */
     public void resetTaskTypes() {
-        for (TaskType taskType : taskTypes.values()) {
+        for (final TaskType taskType : this.taskTypes.values()) {
             taskType.unregisterAll();
         }
     }
 
     /**
-     * Register a task type with the task type manager.
+     * Registers a task type with the task type manager.
      *
      * @param taskType the task type to register
+     * @return true if the task type was successfully registered, false otherwise
      */
-    public boolean registerTaskType(@NotNull TaskType taskType) {
+    public boolean registerTaskType(final @NotNull TaskType taskType) {
         Objects.requireNonNull(taskType, "taskType cannot be null");
 
-        if (!allowRegistrations) {
+        if (!this.registrationsOpen) {
             throw new IllegalStateException("No longer accepting new task types (must be done before quests are loaded)");
         }
 
-        if (exclusions.contains(taskType.getType()) || taskTypes.containsKey(taskType.getType())) {
-            skipped++;
+        final String type = taskType.getType();
+        final Set<String> aliasTypes = taskType.getAliases();
+
+        if (this.exclusions.contains(type) || this.taskTypes.containsKey(type)
+                || !Collections.disjoint(this.exclusions, aliasTypes)
+                || !Collections.disjoint(this.taskTypes.keySet(), aliasTypes)
+                || !Collections.disjoint(this.aliases.keySet(), aliasTypes)) {
+            this.skipped++;
             return false;
         }
 
-        taskTypes.put(taskType.getType(), taskType);
-        for (String alias : taskType.getAliases()) {
-            aliases.put(alias, taskType.getType());
+        this.taskTypes.put(type, taskType);
+        for (final String alias : taskType.getAliases()) {
+            this.aliases.put(alias, type);
         }
 
         return true;
     }
 
     /**
-     * Register a task type with the task type manager.
+     * Registers a task type with the task type manager using suppliers.
      *
      * @param taskTypeSupplier supplier of the task type to register
      * @param compatibilitySuppliers suppliers to check for task type compatibility
+     * @return true if the task type was successfully registered, false otherwise
      */
-    public boolean registerTaskType(@NotNull Supplier<TaskType> taskTypeSupplier, @NotNull BooleanSupplier... compatibilitySuppliers) {
+    public boolean registerTaskType(final @NotNull Supplier<TaskType> taskTypeSupplier, final @NotNull BooleanSupplier @NotNull ... compatibilitySuppliers) {
         Objects.requireNonNull(taskTypeSupplier, "taskTypeSupplier cannot be null");
 
-        if (!allowRegistrations) {
+        if (!this.registrationsOpen) {
             throw new IllegalStateException("No longer accepting new task types (must be done before quests are loaded)");
         }
 
-        for (BooleanSupplier supplier : compatibilitySuppliers) {
+        for (final BooleanSupplier supplier : compatibilitySuppliers) {
             if (!supplier.getAsBoolean()) {
+                this.unsupported++;
                 return false;
             }
         }
 
-        return registerTaskType(taskTypeSupplier.get());
+        return this.registerTaskType(taskTypeSupplier.get());
     }
 
     /**
-     * Register a quest with its task types. This will register the quest to each task type it contains.
+     * Registers a quest with its task types. This will register the quest to each task type it contains.
      *
      * @param quest the quest to register
      */
-    public void registerQuestTasksWithTaskTypes(@NotNull Quest quest) {
+    public void registerQuestTasksWithTaskTypes(final @NotNull Quest quest) {
         Objects.requireNonNull(quest, "quest cannot be null");
 
-        if (allowRegistrations) {
+        if (this.registrationsOpen) {
             throw new IllegalStateException("Still accepting new task types (type registrations must be closed before registering quests)");
         }
-        for (Task task : quest.getTasks()) {
-            TaskType t;
-            if ((t = getTaskType(task.getType())) != null) {
 
-                t.registerQuest(quest);
+        for (final Task task : quest.getTasks()) {
+            final TaskType taskType = this.getTaskType(task.getType());
+
+            if (taskType != null) {
+                taskType.registerQuest(quest);
             }
         }
     }
 
     /**
-     * Get a registered task type by type
+     * Gets a registered task type by type.
      *
      * @param type the type to check
-     * @return {@link TaskType}
+     * @return the {@link TaskType} if found, null otherwise
      */
-    public @Nullable TaskType getTaskType(@NotNull String type) {
+    public @Nullable TaskType getTaskType(final @NotNull String type) {
         Objects.requireNonNull(type, "type cannot be null");
 
-        TaskType taskType = taskTypes.get(type);
-        if (taskType == null) {
-            if (aliases.get(type) != null) {
-                return taskTypes.get(aliases.get(type));
-            }
-        }
-        return taskType;
-    }
-
-    /**
-     * Get the actual name of a task type, following aliases
-     *
-     * @param taskType name of task type
-     * @return actual name
-     */
-    public @Nullable String resolveTaskTypeName(@NotNull String taskType) {
-        Objects.requireNonNull(taskType, "taskType cannot be null");
-
-        if (taskTypes.containsKey(taskType)) {
+        final TaskType taskType = this.taskTypes.get(type);
+        if (taskType != null) {
             return taskType;
         }
-        if (aliases.containsKey(taskType)) {
-            return aliases.get(taskType);
+
+        final String aliasType = this.aliases.get(type);
+        if (aliasType != null) {
+            return this.taskTypes.get(aliasType);
         }
+
         return null;
     }
 
     /**
-     * @return immutable {@link List} containing all task type exclusions
+     * Gets the actual name of a task type, following aliases.
+     *
+     * @param type name of task type
+     * @return the actual name of the task type, or null if not found
      */
-    public @NotNull List<String> getExclusions() {
-        return Collections.unmodifiableList(exclusions);
+    public @Nullable String resolveTaskTypeName(final @NotNull String type) {
+        Objects.requireNonNull(type, "type cannot be null");
+
+        return this.taskTypes.containsKey(type)
+                ? type
+                : this.aliases.get(type);
     }
 
     /**
-     * @return number of task types skipped due to exclusions / name conflicts
+     * Returns an immutable set containing all task type exclusions.
+     *
+     * @return immutable {@link Set} containing all task type exclusions
+     */
+    public @NotNull Set<String> getExclusions() {
+        return Collections.unmodifiableSet(this.exclusions);
+    }
+
+    /**
+     * Returns the number of task types skipped due to exclusions or name conflicts.
+     *
+     * @return number of task types skipped
      */
     public int getSkipped() {
-        return skipped;
+        return this.skipped;
+    }
+
+    /**
+     * Returns the number of task types skipped due to failing to meet specified requirements.
+     *
+     * @return number of task types skipped due to failing to meet specified requirements
+     */
+    public int getUnsupported() {
+        return this.unsupported;
     }
 }

--- a/docs/configuration/creating-a-quest.md
+++ b/docs/configuration/creating-a-quest.md
@@ -183,6 +183,32 @@ startstring:
  - " &8- &7You must break 30 blocks."
 ```
 
+## Cancel string
+
+
+*`cancelstring`*
+
+**Optional.** This is a list of messages which will be sent to the
+player when they cancel the quest.
+
+``` yaml
+cancelstring:
+ - " &8- &7You cancelled the quest to break 30 blocks."
+```
+
+## Expiry string
+
+
+*`expirystring`*
+
+**Optional.** This is a list of messages which will be sent to the
+player when their quest has expired.
+
+``` yaml
+expirystring:
+ - " &8- &7The quest to break 30 blocks just expired."
+```
+
 ## Reward string
 
   

--- a/docs/configuration/defining-items.md
+++ b/docs/configuration/defining-items.md
@@ -318,6 +318,19 @@ item:
   id: "itemsadder"  #itemsdadder id
 ```
 
+#### Oraxen
+
+**Oraxen quest items** are ItemStacks which belong to the
+Oraxen plugin.
+
+    items/testitem.yml
+
+``` yaml
+type: "oraxen"
+item:
+  id: "oraxen_id"  #oraxen id
+```
+
 ### Referencing a quest item
 
 In most cases where an ItemStack is accepted in Quests, you can simply

--- a/docs/task-types/bucketentity-(task-type).md
+++ b/docs/task-types/bucketentity-(task-type).md
@@ -1,0 +1,36 @@
+---
+title: bucketentity
+parent: Built-in task types
+grand_parent: Task types
+---
+
+# bucketentity (task type)
+
+Not released yet (dev builds)
+{: .label .label-green }
+
+Capture specific entity in a bucket.
+
+## Options
+
+| Key           | Description                                            | Type                   | Required | Default | Notes                                                                                                                                                                                                                                                                        |
+|---------------|--------------------------------------------------------|------------------------|----------|---------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `amount`      | The number of buckets to capture an entity in.         | Integer                | Yes      | \-      | \-                                                                                                                                                                                                                                                                           |
+| `item`        | The specific bucket to capture.                        | Material, or ItemStack | No       | \-      | Accepts standard [item definition](../configuration/defining-items). Please see [this list](https://hub.spigotmc.org/javadocs/bukkit/org/bukkit/Material.html) (1.13+) or [this list](https://helpch.at/docs/1.12.2/org/bukkit/Material.html) (1.8-1.12) for material names. |
+| `data`        | The data code for the item.                            | Integer                | No       | 0       | This field is not used in Minecraft versions 1.13+, nor is it compatible with ItemStack definitions.                                                                                                                                                                         |
+| `exact-match` | Whether the item should exactly match what is defined. | Boolean                | No       | true    | \-                                                                                                                                                                                                                                                                           |
+| `worlds`      | Worlds which should count towards the progress.        | List of world names    | No       | \-      | \-                                                                                                                                                                                                                                                                           |
+
+## Examples
+
+Capture 8 axolotls in buckets:
+
+``` yaml
+bucketentity:
+  type: "bucketentity"
+  bucket: AXOLOTL_BUCKET                # (OPTIONAL) bucket to capture the entity
+  exact-match: false                    # (OPTIONAL) ignore the axolotl variation nbt
+  amount: 8                             # amount of times to capture entity
+  worlds:                               # (OPTIONAL) restrict to certain worlds
+   - "world"
+```

--- a/docs/task-types/curing-(task-type).md
+++ b/docs/task-types/curing-(task-type).md
@@ -1,0 +1,29 @@
+---
+title: curing
+parent: Built-in task types
+grand_parent: Task types
+---
+
+# curing (task type)
+
+Not released yet (dev builds)
+{: .label .label-green }
+
+Cure a set amount of zombie villagers.
+
+## Options
+
+| Key      | Description                                     | Type                | Required | Default | Notes |
+|----------|-------------------------------------------------|---------------------|----------|---------|-------|
+| `amount` | The number of zombie villagers to cure.         | Integer             | Yes      | \-      | \-    |
+| `worlds` | Worlds which should count towards the progress. | List of world names | No       | \-      | \-    |
+
+## Examples
+
+Cure 8 zombie villagers:
+
+``` yaml
+curing:
+  type: "curing"
+  amount: 8               # amount of times to cure a zombie villager
+```

--- a/docs/task-types/itembreaking-(task-type).md
+++ b/docs/task-types/itembreaking-(task-type).md
@@ -1,0 +1,34 @@
+---
+title: itembreaking
+parent: Built-in task types
+grand_parent: Task types
+---
+
+# itembreaking (task type)
+
+Not released yet (dev builds)
+{: .label .label-green }
+
+Break a set amount of certain items (by reducing durability to 0).
+
+## Options
+
+| Key           | Description                                            | Type                   | Required | Default | Notes                                                                                                                                                                                                                                                       |
+|---------------|--------------------------------------------------------|------------------------|----------|---------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `amount`      | The number of items to break.                          | Integer                | Yes      | \-      | \-                                                                                                                                                                                                                                                          |
+| `item`        | The specific item to break.                            | Material, or ItemStack | No       | \-      | Accepts standard [item definition](defining_items). Please see [this list](https://hub.spigotmc.org/javadocs/bukkit/org/bukkit/Material.html) (1.13+) or [this list](https://helpch.at/docs/1.12.2/org/bukkit/Material.html) (1.8-1.12) for material names. |
+| `data`        | The data code for the item.                            | Integer                | No       | 0       | This field is not used in Minecraft versions 1.13+, nor is it compatible with ItemStack definitions.                                                                                                                                                        |
+| `exact-match` | Whether the item should exactly match what is defined. | Boolean                | No       | true    | \-                                                                                                                                                                                                                                                          |
+| `worlds`      | Worlds which should count towards the progress.        | List of world names    | No       | \-      | \-                                                                                                                                                                                                                                                          |
+
+## Examples
+
+Break 8 diamond pickaxes:
+
+``` yaml
+itembreaking:
+  type: "itembreaking"
+  amount: 8               # amount of items to break
+  item: DIAMOND_PICKAXE   # item to break
+  exact-match: false      # we need to ignore nbt
+```

--- a/docs/task-types/itemdamaging-(task-type).md
+++ b/docs/task-types/itemdamaging-(task-type).md
@@ -1,0 +1,34 @@
+---
+title: itemdamaging
+parent: Built-in task types
+grand_parent: Task types
+---
+
+# itemdamaging (task type)
+
+Not released yet (dev builds)
+{: .label .label-green }
+
+Damage certain items with a set amount of damage (by reducing durability).
+
+## Options
+
+| Key           | Description                                            | Type                   | Required | Default | Notes                                                                                                                                                                                                                                                       |
+|---------------|--------------------------------------------------------|------------------------|----------|---------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `amount`      | The number of damage to damage the item.               | Integer                | Yes      | \-      | \-                                                                                                                                                                                                                                                          |
+| `item`        | The specific item to damage.                           | Material, or ItemStack | No       | \-      | Accepts standard [item definition](defining_items). Please see [this list](https://hub.spigotmc.org/javadocs/bukkit/org/bukkit/Material.html) (1.13+) or [this list](https://helpch.at/docs/1.12.2/org/bukkit/Material.html) (1.8-1.12) for material names. |
+| `data`        | The data code for the item.                            | Integer                | No       | 0       | This field is not used in Minecraft versions 1.13+, nor is it compatible with ItemStack definitions.                                                                                                                                                        |
+| `exact-match` | Whether the item should exactly match what is defined. | Boolean                | No       | true    | \-                                                                                                                                                                                                                                                          |
+| `worlds`      | Worlds which should count towards the progress.        | List of world names    | No       | \-      | \-                                                                                                                                                                                                                                                          |
+
+## Examples
+
+Damage diamond pickaxes with 12000 points of damage:
+
+``` yaml
+itemdamaging:
+  type: "itemdamaging"
+  amount: 12000           # amount of damage to damage the item
+  item: DIAMOND_PICKAXE   # item to damage
+  exact-match: false      # we need to ignore nbt
+```

--- a/docs/task-types/itemmending-(task-type).md
+++ b/docs/task-types/itemmending-(task-type).md
@@ -1,0 +1,34 @@
+---
+title: itemmending
+parent: Built-in task types
+grand_parent: Task types
+---
+
+# itemmending (task type)
+
+Not released yet (dev builds)
+{: .label .label-green }
+
+Mend certain items with a set amount of repair (by increasing durability with mending enchantment).
+
+## Options
+
+| Key           | Description                                            | Type                   | Required | Default | Notes                                                                                                                                                                                                                                                       |
+|---------------|--------------------------------------------------------|------------------------|----------|---------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `amount`      | The number of repair to mend the item.                 | Integer                | Yes      | \-      | \-                                                                                                                                                                                                                                                          |
+| `item`        | The specific item to mend.                             | Material, or ItemStack | No       | \-      | Accepts standard [item definition](defining_items). Please see [this list](https://hub.spigotmc.org/javadocs/bukkit/org/bukkit/Material.html) (1.13+) or [this list](https://helpch.at/docs/1.12.2/org/bukkit/Material.html) (1.8-1.12) for material names. |
+| `data`        | The data code for the item.                            | Integer                | No       | 0       | This field is not used in Minecraft versions 1.13+, nor is it compatible with ItemStack definitions.                                                                                                                                                        |
+| `exact-match` | Whether the item should exactly match what is defined. | Boolean                | No       | true    | \-                                                                                                                                                                                                                                                          |
+| `worlds`      | Worlds which should count towards the progress.        | List of world names    | No       | \-      | \-                                                                                                                                                                                                                                                          |
+
+## Examples
+
+Mend diamond pickaxes with 12000 points of repair:
+
+``` yaml
+itemmending:
+  type: "itemmending"
+  amount: 12000           # amount of repair to mend the item
+  item: DIAMOND_PICKAXE   # item to mend
+  exact-match: false      # we need to ignore nbt
+```

--- a/docs/task-types/resurrecting-(task-type).md
+++ b/docs/task-types/resurrecting-(task-type).md
@@ -1,0 +1,29 @@
+---
+title: resurrecting
+parent: Built-in task types
+grand_parent: Task types
+---
+
+# resurrecting (task type)
+
+Not released yet (dev builds)
+{: .label .label-green }
+
+Resurrect a set amount of times (by totem of undying usage).
+
+## Options
+
+| Key      | Description                                     | Type                | Required | Default | Notes |
+|----------|-------------------------------------------------|---------------------|----------|---------|-------|
+| `amount` | The number of times to resurrect.               | Integer             | Yes      | \-      | \-    |
+| `worlds` | Worlds which should count towards the progress. | List of world names | No       | \-      | \-    |
+
+## Examples
+
+Resurrect 5 times:
+
+``` yaml
+resurrecting:
+  type: "resurrecting"
+  amount: 5               # amount of times to resurrect
+```


### PR DESCRIPTION
Closes https://github.com/LMBishop/Quests/issues/545 (only curing is possible to implement)
Closes https://github.com/LMBishop/Quests/issues/489 (added curing task type)
Closes https://github.com/LMBishop/Quests/issues/645 (fixed autosave)
Closes https://github.com/LMBishop/Quests/issues/672 (made the error a bit cleaner)
Closes https://github.com/LMBishop/Quests/issues/670 (already fixed)
Closes https://github.com/LMBishop/Quests/issues/659 (made the error a bit cleaner)
Closes https://github.com/LMBishop/Quests/issues/629 (optimized debugging)
Closes https://github.com/LMBishop/Quests/issues/667 (added cancelstring and expirystring)