### PR TITLE
Fix ConcurrentModificationException in checkExpiredQuests method

### DIFF
--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/questcompleter/BukkitQuestCompleter.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/questcompleter/BukkitQuestCompleter.java
@@ -15,6 +15,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.Collections;
 import java.util.LinkedList;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
@@ -40,6 +41,8 @@ public class BukkitQuestCompleter implements QuestCompleter, Runnable {
 
     private void checkExpiredQuests(QPlayer qPlayer) {
         QuestProgressFile questProgressFile = qPlayer.getQuestProgressFile();
+        List<Quest> toExpire = new ArrayList<>();
+
         for (QuestProgress questProgress : questProgressFile.getAllQuestProgress()) {
             if (!questProgress.isStarted()) {
                 continue;
@@ -51,8 +54,12 @@ public class BukkitQuestCompleter implements QuestCompleter, Runnable {
             }
 
             if (questProgressFile.getTimeRemainingFor(quest) == 0) {
-                qPlayer.expireQuest(quest);
+                toExpire.add(quest);
             }
+        }
+
+        for (Quest expiredQuest : toExpire) {
+            qPlayer.expireQuest(expiredQuest);
         }
     }
 


### PR DESCRIPTION
Fix ConcurrentModificationException in checkExpiredQuests method

This PR addresses the ConcurrentModificationException that was occurring in the `checkExpiredQuests` method by collecting the quests to expire in a separate list and removing them after iterating through the original collection. This avoids modifying the collection while iterating, thus preventing the exception. This resolves the issue described in [#760](https://github.com/LMBishop/Quests/issues/760).

### Changes:
- Created a temporary list to collect quests to expire, then remove them after the iteration.
- Ensured that the collection is not modified during iteration.

Closes #760
