### PR TITLE
Fixes a bug with fire aspect and entity killing quests

### DIFF
--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/type/MobkillingTaskType.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/tasktype/type/MobkillingTaskType.java
@@ -63,8 +63,15 @@ public final class MobkillingTaskType extends BukkitTaskType {
         @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
         public void onEntityDeath(EntityDeathEvent event) {
             LivingEntity entity = event.getEntity();
-            EntityDamageEvent damageEvent = entity.getLastDamageCause();
-            Player player = plugin.getVersionSpecificHandler().getDamager(damageEvent);
+            Player killer = entity.getKiller();
+            Player player;
+
+            if (killer != null) {
+                player = killer;
+            } else {
+                EntityDamageEvent damageEvent = entity.getLastDamageCause();
+                player = plugin.getVersionSpecificHandler().getDamager(damageEvent);
+            }
 
             handle(player, entity, 1);
         }


### PR DESCRIPTION
Fixes #752 by switching the method of finding the entity killer from last damage source to entity.getKiller().