### PR TITLE
Add displaySlot support for quest menu ordering

### DIFF
--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/config/BukkitQuestsLoader.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/config/BukkitQuestsLoader.java
@@ -290,7 +290,11 @@ public class BukkitQuestsLoader implements QuestsLoader {
                         boolean hidden = config.getBoolean("options.hidden", false);
                         int cooldownTime = config.getInt("options.cooldown.time", 10);
                         int timeLimtTime = config.getInt("options.time-limit.time", 10);
+
+                        // Modifica: Lettura slot manuale (default -1) e ordinamento
+                        int displaySlot = config.getInt("options.display-slot", -1);
                         int sortOrder = config.getInt("options.sort-order", 1);
+
                         String category = config.getString("options.category");
                         Map<String, String> placeholders = new HashMap<>();
                         Map<String, String> progressPlaceholders = new HashMap<>();
@@ -320,6 +324,8 @@ public class BukkitQuestsLoader implements QuestsLoader {
                                 .withProgressPlaceholders(progressPlaceholders)
                                 .withCooldown(cooldownTime)
                                 .withTimeLimit(timeLimtTime)
+                                // Modifica: Passiamo al builder il displaySlot
+                                .withDisplaySlot(displaySlot)
                                 .withSortOrder(sortOrder)
                                 .withCooldownEnabled(cooldown)
                                 .withTimeLimitEnabled(timeLimit)

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/menu/QuestQMenu.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/menu/QuestQMenu.java
@@ -10,6 +10,8 @@ import com.leonardobishop.quests.common.player.QPlayer;
 import com.leonardobishop.quests.common.player.questprogressfile.QuestProgress;
 import com.leonardobishop.quests.common.quest.Category;
 import com.leonardobishop.quests.common.quest.Quest;
+import me.clip.placeholderapi.PlaceholderAPI;
+import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
 import org.bukkit.Bukkit;
 import org.jspecify.annotations.Nullable;
 
@@ -25,7 +27,7 @@ public class QuestQMenu extends PaginatedQMenu {
     private final String categoryName;
 
     public QuestQMenu(BukkitQuestsPlugin plugin, QPlayer owner, List<Quest> quests, @Nullable Category category, CategoryQMenu categoryQMenu) {
-        super(owner, Chat.legacyColor(guiName(plugin, category)),
+        super(owner, Chat.legacyColor(PlaceholderAPI.setPlaceholders(Bukkit.getPlayer(owner.getPlayerUUID()) ,(guiName(plugin, category)))),
                 plugin.getQuestsConfig().getBoolean("options.trim-gui-size.quests-menu"), 54, plugin);
 
         BukkitQuestsConfig config = (BukkitQuestsConfig) plugin.getQuestsConfig();
@@ -58,7 +60,7 @@ public class QuestQMenu extends PaginatedQMenu {
         } else {
             path = "custom-elements.quests";
         }
-        super.populate(path, filteredQuests, backMenuElement);
+        super.populate(path, filteredQuests, backMenuElement, plugin, this);
     }
 
     public String getCategoryName() {
@@ -66,6 +68,7 @@ public class QuestQMenu extends PaginatedQMenu {
     }
 
     private static String guiName(final BukkitQuestsPlugin plugin, final @Nullable Category category) {
+
         if (category != null) {
             final String guiName = category.getGUIName();
 
@@ -73,7 +76,6 @@ public class QuestQMenu extends PaginatedQMenu {
                 return guiName;
             }
         }
-
         return plugin.getQuestsConfig().getString("options.guinames.quests-menu");
     }
 }

--- a/common/src/main/java/com/leonardobishop/quests/common/quest/Quest.java
+++ b/common/src/main/java/com/leonardobishop/quests/common/quest/Quest.java
@@ -31,7 +31,13 @@ public class Quest implements Comparable<Quest> {
     private int cooldown;
     private boolean timeLimitEnabled;
     private int timeLimit;
+
+    // Manteniamo sortOrder per compatibilità ma useremo displaySlot per l'ordinamento
     private int sortOrder;
+
+    // NUOVO CAMPO
+    private int displaySlot;
+
     private boolean permissionRequired;
     private boolean autoStartEnabled;
     private boolean cancellable;
@@ -312,6 +318,14 @@ public class Quest implements Comparable<Quest> {
     }
 
     /**
+     * Get the specific display slot for this quest.
+     * * @return the slot index (0-53) or -1 if not set
+     */
+    public int getDisplaySlot() {
+        return displaySlot;
+    }
+
+    /**
      * Get if quest-specific autostart is enabled for this quest.
      *
      * @return boolean
@@ -357,7 +371,8 @@ public class Quest implements Comparable<Quest> {
     }
 
     /**
-     * Compare the sort orders for this quest with another quest.
+     * Compare the quests. 
+     * Modified to prioritise displaySlot over sortOrder.
      *
      * @see Comparable#compareTo(Object)
      * @param quest the quest to compare with
@@ -365,7 +380,8 @@ public class Quest implements Comparable<Quest> {
      */
     @Override
     public int compareTo(@NotNull Quest quest) {
-        return (sortOrder - quest.sortOrder);
+        // MODIFICA: Utilizza displaySlot per il confronto
+        return Integer.compare(this.displaySlot, quest.displaySlot);
     }
 
     public static class Builder {
@@ -387,6 +403,8 @@ public class Quest implements Comparable<Quest> {
         private boolean timeLimitEnabled = false;
         private int timeLimit = 0;
         private int sortOrder = 1;
+        // NUOVO CAMPO NEL BUILDER
+        private int displaySlot = -1;
         private boolean permissionRequired = false;
         private boolean autoStartEnabled = false;
         private boolean cancellable = true;
@@ -453,6 +471,12 @@ public class Quest implements Comparable<Quest> {
 
         public Builder withSortOrder(int sortOrder) {
             this.sortOrder = sortOrder;
+            return this;
+        }
+
+        // NUOVO METODO NEL BUILDER
+        public Builder withDisplaySlot(int displaySlot) {
+            this.displaySlot = displaySlot;
             return this;
         }
 
@@ -545,6 +569,8 @@ public class Quest implements Comparable<Quest> {
             quest.timeLimitEnabled = this.timeLimitEnabled;
             quest.timeLimit = this.timeLimit;
             quest.sortOrder = this.sortOrder;
+            // ASSEGNAZIONE NUOVO CAMPO
+            quest.displaySlot = this.displaySlot;
             quest.permissionRequired = this.permissionRequired;
             quest.autoStartEnabled = this.autoStartEnabled;
             quest.countsTowardsLimit = this.countsTowardsLimit;


### PR DESCRIPTION
Introduces a new displaySlot field to Quest and updates menu logic to allow quests to be placed in specific inventory slots. The PaginatedQMenu and QuestQMenu classes are modified to prioritize displaySlot over sortOrder for quest placement, enabling manual slot assignment via configuration.