### PR TITLE
Upgrade Gradle and add support for Minecraft versions 26.1.x

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,55 +1,55 @@
 name: Build plugin
-on: [pull_request, push]
+on: [ pull_request, push ]
 jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-latest]
-        distribution: [temurin]
-        java-version: ["21"]
+        os: [ ubuntu-latest ]
+        distribution: [ temurin ]
+        java-version: [ "21" ]
     runs-on: ${{ matrix.os }}
     if: "!startsWith(github.event.head_commit.message, '[ci-skip]')"
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-      - name: "Setup JDK (${{ matrix.distribution }} ${{ matrix.java-version }})"
-        uses: actions/setup-java@v4
-        with:
-          distribution: "${{ matrix.distribution }}"
-          java-version: "${{ matrix.java-version }}"
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
-      - name: Execute Gradle build
-        run: ./gradlew --no-daemon --stacktrace
-      - name: "Upload the Java ${{ matrix.java-version }} plugin JAR"
-        uses: actions/upload-artifact@v4
-        with:
-          name: "! Quests-JDK${{ matrix.java-version }}"
-          path: |
-            build/libs/*.jar
-            !build/libs/*-downgraded-*.jar
-          if-no-files-found: error
-      - name: Upload the downgraded Java 8 plugin JAR
-        uses: actions/upload-artifact@v4
-        with:
-          name: Quests-JDK1.8 (use at your own risk)
-          path: build/libs/*-downgraded-8-shaded.jar
-          if-no-files-found: error
-      - name: Upload the downgraded Java 11 plugin JAR
-        uses: actions/upload-artifact@v4
-        with:
-          name: Quests-JDK11 (use at your own risk)
-          path: build/libs/*-downgraded-11-shaded.jar
-          if-no-files-found: error
-      - name: Upload the downgraded Java 16 plugin JAR
-        uses: actions/upload-artifact@v4
-        with:
-          name: Quests-JDK16 (use at your own risk)
-          path: build/libs/*-downgraded-16-shaded.jar
-          if-no-files-found: error
-      - name: Upload the downgraded Java 17 plugin JAR
-        uses: actions/upload-artifact@v4
-        with:
-          name: Quests-JDK17 (use at your own risk)
-          path: build/libs/*-downgraded-17-shaded.jar
-          if-no-files-found: error
+    - name: Checkout repository
+      uses: actions/checkout@v6
+    - name: "Setup JDK (${{ matrix.distribution }} ${{ matrix.java-version }})"
+      uses: actions/setup-java@v5
+      with:
+        distribution: "${{ matrix.distribution }}"
+        java-version: "${{ matrix.java-version }}"
+    - name: Setup Gradle
+      uses: gradle/actions/setup-gradle@v6
+    - name: Execute Gradle build
+      run: ./gradlew --no-daemon --stacktrace
+    - name: "Upload the Java ${{ matrix.java-version }} plugin JAR"
+      uses: actions/upload-artifact@v7
+      with:
+        name: "! Quests-JDK${{ matrix.java-version }}"
+        path: |
+          build/libs/*.jar
+          !build/libs/*-downgraded-*.jar
+        if-no-files-found: error
+    - name: Upload the downgraded Java 8 plugin JAR
+      uses: actions/upload-artifact@v7
+      with:
+        name: Quests-JDK1.8 (use at your own risk)
+        path: build/libs/*-downgraded-8-shaded.jar
+        if-no-files-found: error
+    - name: Upload the downgraded Java 11 plugin JAR
+      uses: actions/upload-artifact@v7
+      with:
+        name: Quests-JDK11 (use at your own risk)
+        path: build/libs/*-downgraded-11-shaded.jar
+        if-no-files-found: error
+    - name: Upload the downgraded Java 16 plugin JAR
+      uses: actions/upload-artifact@v7
+      with:
+        name: Quests-JDK16 (use at your own risk)
+        path: build/libs/*-downgraded-16-shaded.jar
+        if-no-files-found: error
+    - name: Upload the downgraded Java 17 plugin JAR
+      uses: actions/upload-artifact@v7
+      with:
+        name: Quests-JDK17 (use at your own risk)
+        path: build/libs/*-downgraded-17-shaded.jar
+        if-no-files-found: error

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,26 +1,34 @@
 name: Build plugin
+
 on: [ pull_request, push ]
+
 jobs:
   build:
     strategy:
       matrix:
         os: [ ubuntu-latest ]
         distribution: [ temurin ]
-        java-version: [ "21" ]
+        java-version: [ "25" ]
+
     runs-on: ${{ matrix.os }}
     if: "!startsWith(github.event.head_commit.message, '[ci-skip]')"
+
     steps:
     - name: Checkout repository
       uses: actions/checkout@v6
+
     - name: "Setup JDK (${{ matrix.distribution }} ${{ matrix.java-version }})"
       uses: actions/setup-java@v5
       with:
         distribution: "${{ matrix.distribution }}"
         java-version: "${{ matrix.java-version }}"
+
     - name: Setup Gradle
       uses: gradle/actions/setup-gradle@v6
+
     - name: Execute Gradle build
       run: ./gradlew --no-daemon --stacktrace
+
     - name: "Upload the Java ${{ matrix.java-version }} plugin JAR"
       uses: actions/upload-artifact@v7
       with:
@@ -29,27 +37,38 @@ jobs:
           build/libs/*.jar
           !build/libs/*-downgraded-*.jar
         if-no-files-found: error
+
     - name: Upload the downgraded Java 8 plugin JAR
       uses: actions/upload-artifact@v7
       with:
         name: Quests-JDK1.8 (use at your own risk)
         path: build/libs/*-downgraded-8-shaded.jar
         if-no-files-found: error
+
     - name: Upload the downgraded Java 11 plugin JAR
       uses: actions/upload-artifact@v7
       with:
         name: Quests-JDK11 (use at your own risk)
         path: build/libs/*-downgraded-11-shaded.jar
         if-no-files-found: error
+
     - name: Upload the downgraded Java 16 plugin JAR
       uses: actions/upload-artifact@v7
       with:
         name: Quests-JDK16 (use at your own risk)
         path: build/libs/*-downgraded-16-shaded.jar
         if-no-files-found: error
+
     - name: Upload the downgraded Java 17 plugin JAR
       uses: actions/upload-artifact@v7
       with:
         name: Quests-JDK17 (use at your own risk)
         path: build/libs/*-downgraded-17-shaded.jar
+        if-no-files-found: error
+
+    - name: Upload the downgraded Java 21 plugin JAR
+      uses: actions/upload-artifact@v7
+      with:
+        name: Quests-JDK21 (use at your own risk)
+        path: build/libs/*-downgraded-21-shaded.jar
         if-no-files-found: error

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,61 +14,61 @@ jobs:
     if: "!startsWith(github.event.head_commit.message, '[ci-skip]')"
 
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v6
+      - name: Checkout repository
+        uses: actions/checkout@v6
 
-    - name: "Setup JDK (${{ matrix.distribution }} ${{ matrix.java-version }})"
-      uses: actions/setup-java@v5
-      with:
-        distribution: "${{ matrix.distribution }}"
-        java-version: "${{ matrix.java-version }}"
+      - name: "Setup JDK (${{ matrix.distribution }} ${{ matrix.java-version }})"
+        uses: actions/setup-java@v5
+        with:
+          distribution: "${{ matrix.distribution }}"
+          java-version: "${{ matrix.java-version }}"
 
-    - name: Setup Gradle
-      uses: gradle/actions/setup-gradle@v6
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v6
 
-    - name: Execute Gradle build
-      run: ./gradlew --no-daemon --stacktrace
+      - name: Execute Gradle build
+        run: ./gradlew --no-daemon --stacktrace
 
-    - name: "Upload the Java ${{ matrix.java-version }} plugin JAR"
-      uses: actions/upload-artifact@v7
-      with:
-        name: "! Quests-JDK${{ matrix.java-version }}"
-        path: |
-          build/libs/*.jar
-          !build/libs/*-downgraded-*.jar
-        if-no-files-found: error
+      - name: "Upload the Java ${{ matrix.java-version }} plugin JAR"
+        uses: actions/upload-artifact@v7
+        with:
+          name: "! Quests-JDK${{ matrix.java-version }}"
+          path: |
+            build/libs/*.jar
+            !build/libs/*-downgraded-*.jar
+          if-no-files-found: error
 
-    - name: Upload the downgraded Java 8 plugin JAR
-      uses: actions/upload-artifact@v7
-      with:
-        name: Quests-JDK1.8 (use at your own risk)
-        path: build/libs/*-downgraded-8-shaded.jar
-        if-no-files-found: error
+      - name: Upload the downgraded Java 8 plugin JAR
+        uses: actions/upload-artifact@v7
+        with:
+          name: Quests-JDK1.8 (use at your own risk)
+          path: build/libs/*-downgraded-8-shaded.jar
+          if-no-files-found: error
 
-    - name: Upload the downgraded Java 11 plugin JAR
-      uses: actions/upload-artifact@v7
-      with:
-        name: Quests-JDK11 (use at your own risk)
-        path: build/libs/*-downgraded-11-shaded.jar
-        if-no-files-found: error
+      - name: Upload the downgraded Java 11 plugin JAR
+        uses: actions/upload-artifact@v7
+        with:
+          name: Quests-JDK11 (use at your own risk)
+          path: build/libs/*-downgraded-11-shaded.jar
+          if-no-files-found: error
 
-    - name: Upload the downgraded Java 16 plugin JAR
-      uses: actions/upload-artifact@v7
-      with:
-        name: Quests-JDK16 (use at your own risk)
-        path: build/libs/*-downgraded-16-shaded.jar
-        if-no-files-found: error
+      - name: Upload the downgraded Java 16 plugin JAR
+        uses: actions/upload-artifact@v7
+        with:
+          name: Quests-JDK16 (use at your own risk)
+          path: build/libs/*-downgraded-16-shaded.jar
+          if-no-files-found: error
 
-    - name: Upload the downgraded Java 17 plugin JAR
-      uses: actions/upload-artifact@v7
-      with:
-        name: Quests-JDK17 (use at your own risk)
-        path: build/libs/*-downgraded-17-shaded.jar
-        if-no-files-found: error
+      - name: Upload the downgraded Java 17 plugin JAR
+        uses: actions/upload-artifact@v7
+        with:
+          name: Quests-JDK17 (use at your own risk)
+          path: build/libs/*-downgraded-17-shaded.jar
+          if-no-files-found: error
 
-    - name: Upload the downgraded Java 21 plugin JAR
-      uses: actions/upload-artifact@v7
-      with:
-        name: Quests-JDK21 (use at your own risk)
-        path: build/libs/*-downgraded-21-shaded.jar
-        if-no-files-found: error
+      - name: Upload the downgraded Java 21 plugin JAR
+        uses: actions/upload-artifact@v7
+        with:
+          name: Quests-JDK21 (use at your own risk)
+          path: build/libs/*-downgraded-21-shaded.jar
+          if-no-files-found: error

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,21 +1,26 @@
 name: Publish plugin to repository
+
 on:
   push:
     tags:
     - '*'
+
 jobs:
   publish:
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
+
     steps:
     - uses: actions/checkout@v6
+
     - name: Set up Java
       uses: actions/setup-java@v5
       with:
         java-version: '8.0'
         distribution: 'adopt'
+
     - name: Publish to repository
       run: gradle publish
       env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,22 +2,22 @@ name: Publish plugin to repository
 on:
   push:
     tags:
-      - '*'
+    - '*'
 jobs:
   publish:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v2
-      - name: Set up Java
-        uses: actions/setup-java@v2
-        with:
-          java-version: '8.0'
-          distribution: 'adopt'
-      - name: Publish to repository
-        run: gradle publish
-        env:
-          MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
-          MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
+    - uses: actions/checkout@v6
+    - name: Set up Java
+      uses: actions/setup-java@v5
+      with:
+        java-version: '8.0'
+        distribution: 'adopt'
+    - name: Publish to repository
+      run: gradle publish
+      env:
+        MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
+        MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,7 +3,7 @@ name: Publish plugin to repository
 on:
   push:
     tags:
-    - '*'
+      - '*'
 
 jobs:
   publish:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,8 +18,8 @@ jobs:
     - name: Set up Java
       uses: actions/setup-java@v5
       with:
-        java-version: '8.0'
-        distribution: 'adopt'
+        java-version: '17'
+        distribution: 'temurin'
 
     - name: Publish to repository
       run: gradle publish

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,7 +3,7 @@ name: Publish plugin to repository
 on:
   push:
     tags:
-      - '*'
+    - '*'
 
 jobs:
   publish:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,7 @@ jobs:
         distribution: 'temurin'
 
     - name: Publish to repository
-      run: gradle publish
+      run: ./gradlew publish
       env:
         MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
         MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ UPDATE_MESSAGE
 *.project
 */bin/
 *.settings/
+
+# VS Code
+.vscode/

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,7 +15,7 @@ allprojects {
 
     java {
         toolchain {
-            languageVersion = JavaLanguageVersion.of(21)
+            languageVersion = JavaLanguageVersion.of(25)
         }
     }
 }
@@ -24,7 +24,7 @@ subprojects {
     tasks.withType<JavaCompile> {
         options.compilerArgs = listOf("-Xlint:deprecation", "-Xlint:unchecked")
         options.encoding = Charsets.UTF_8.name()
-        options.release = 21
+        options.release = 25
     }
 
     tasks.withType<Javadoc> {
@@ -89,7 +89,10 @@ val javaVersions = listOf(
     JavaVersion.VERSION_16,
 
     // from 1.18 to 1.20.4
-    JavaVersion.VERSION_17
+    JavaVersion.VERSION_17,
+
+    // from 1.20.4 to 1.21.11
+    JavaVersion.VERSION_21
 )
 
 for (javaVersion in javaVersions) {

--- a/bukkit/build.gradle.kts
+++ b/bukkit/build.gradle.kts
@@ -16,7 +16,10 @@ tasks.withType<ProcessResources> {
 
 repositories {
     // Paper
-    maven("https://repo.papermc.io/repository/maven-public/")
+    maven {
+        name = "papermc"
+        url = uri("https://repo.papermc.io/repository/maven-public/")
+    }
     // Paper (adventure-bom snapshots)
     maven("https://s01.oss.sonatype.org/content/repositories/snapshots/")
     // ASkyBlock, BedWars1058, BentoBox, bStats, Citizens
@@ -71,7 +74,7 @@ dependencies {
     compileOnlyProject(":common")
 
     // Paper
-    compileOnlyServer("io.papermc.paper:paper-api:1.21.11-pre3-R0.1-SNAPSHOT")
+    compileOnly("io.papermc.paper:paper-api:26.1.1.build.+")
 
     // ASkyBlock
     compileOnlyPlugin("com.wasteofplastic:askyblock:3.0.9.4")

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/hook/versionspecific/VersionSpecificHandler.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/hook/versionspecific/VersionSpecificHandler.java
@@ -70,6 +70,8 @@ public interface VersionSpecificHandler {
         this.add(Version.V1_21_2);
         this.add(Version.V1_21_6);
         this.add(Version.V1_21_11);
+        this.add(Version.V26_1);
+        this.add(Version.V26_1_1);
     }});
 
     static VersionSpecificHandler getImplementation(final Version serverVersion) {

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/hook/versionspecific/VersionSpecificHandler_V26_1.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/hook/versionspecific/VersionSpecificHandler_V26_1.java
@@ -4,6 +4,7 @@ import com.leonardobishop.quests.common.versioning.Version;
 import org.jspecify.annotations.NullMarked;
 
 @NullMarked
+@SuppressWarnings("PMD.ClassNamingConventions")
 public class VersionSpecificHandler_V26_1 extends VersionSpecificHandler_V1_21_11 {
 
     @Override

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/hook/versionspecific/VersionSpecificHandler_V26_1.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/hook/versionspecific/VersionSpecificHandler_V26_1.java
@@ -1,0 +1,13 @@
+package com.leonardobishop.quests.bukkit.hook.versionspecific;
+
+import com.leonardobishop.quests.common.versioning.Version;
+import org.jspecify.annotations.NullMarked;
+
+@NullMarked
+public class VersionSpecificHandler_V26_1 extends VersionSpecificHandler_V1_21_11 {
+
+    @Override
+    public Version getMinecraftVersion() {
+        return Version.V26_1;
+    }
+}

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/hook/versionspecific/VersionSpecificHandler_V26_1_1.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/hook/versionspecific/VersionSpecificHandler_V26_1_1.java
@@ -1,0 +1,13 @@
+package com.leonardobishop.quests.bukkit.hook.versionspecific;
+
+import com.leonardobishop.quests.common.versioning.Version;
+import org.jspecify.annotations.NullMarked;
+
+@NullMarked
+public class VersionSpecificHandler_V26_1_1 extends VersionSpecificHandler_V26_1 {
+
+    @Override
+    public Version getMinecraftVersion() {
+        return Version.V26_1_1;
+    }
+}

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/hook/versionspecific/VersionSpecificHandler_V26_1_1.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/hook/versionspecific/VersionSpecificHandler_V26_1_1.java
@@ -4,6 +4,7 @@ import com.leonardobishop.quests.common.versioning.Version;
 import org.jspecify.annotations.NullMarked;
 
 @NullMarked
+@SuppressWarnings("PMD.ClassNamingConventions")
 public class VersionSpecificHandler_V26_1_1 extends VersionSpecificHandler_V26_1 {
 
     @Override

--- a/common/src/main/java/com/leonardobishop/quests/common/versioning/Version.java
+++ b/common/src/main/java/com/leonardobishop/quests/common/versioning/Version.java
@@ -24,6 +24,8 @@ public final class Version implements Comparable<Version> {
     public static final Version V1_21_2 = new Version(1, 21, 2);
     public static final Version V1_21_6 = new Version(1, 21, 6);
     public static final Version V1_21_11 = new Version(1, 21, 11);
+    public static final Version V26_1 = new Version(26, 1);
+    public static final Version V26_1_1 = new Version(26, 1, 1);
     public static final Version UNKNOWN = new Version(Integer.MAX_VALUE);
 
     private final @Nullable String preRelease;

--- a/common/src/main/java/com/leonardobishop/quests/common/versioning/Version.java
+++ b/common/src/main/java/com/leonardobishop/quests/common/versioning/Version.java
@@ -165,7 +165,6 @@ public final class Version implements Comparable<Version> {
                 ? str.substring(plusIndex + 1)
                 : null;
 
-        final int optionalIndex = minusIndex != -1 ? minusIndex : plusIndex;
         String versionCore = optionalIndex != -1 ? str.substring(0, optionalIndex) : str;
         if (versionCore.contains(".build")) {
             versionCore = versionCore.substring(0, versionCore.indexOf(".build"));

--- a/common/src/main/java/com/leonardobishop/quests/common/versioning/Version.java
+++ b/common/src/main/java/com/leonardobishop/quests/common/versioning/Version.java
@@ -165,7 +165,7 @@ public final class Version implements Comparable<Version> {
                 ? str.substring(plusIndex + 1)
                 : null;
 
-        String versionCore = optionalIndex != -1 ? str.substring(0, optionalIndex) : str;
+        String versionCore = minusIndex != -1 ? str.substring(0, minusIndex) : str;
         if (versionCore.contains(".build")) {
             versionCore = versionCore.substring(0, versionCore.indexOf(".build"));
         }

--- a/common/src/main/java/com/leonardobishop/quests/common/versioning/Version.java
+++ b/common/src/main/java/com/leonardobishop/quests/common/versioning/Version.java
@@ -166,7 +166,10 @@ public final class Version implements Comparable<Version> {
                 : null;
 
         final int optionalIndex = minusIndex != -1 ? minusIndex : plusIndex;
-        final String versionCore = optionalIndex != -1 ? str.substring(0, optionalIndex) : str;
+        String versionCore = optionalIndex != -1 ? str.substring(0, optionalIndex) : str;
+        if (versionCore.contains(".build")) {
+            versionCore = versionCore.substring(0, versionCore.indexOf(".build"));
+        }
         final String[] stringVersionParts = versionCore.split("\\.");
         final int[] versionParts = new int[stringVersionParts.length];
 

--- a/common/src/test/java/com/leonardobishop/quests/common/VersionTest.java
+++ b/common/src/test/java/com/leonardobishop/quests/common/VersionTest.java
@@ -97,6 +97,8 @@ public final class VersionTest {
         assertEquals("1.21.11-rc2-R0.1-SNAPSHOT", Version.fromString("1.21.11-rc2-R0.1-SNAPSHOT").toString());
         assertEquals("1.21.11-rc3-R0.1-SNAPSHOT", Version.fromString("1.21.11-rc3-R0.1-SNAPSHOT").toString());
         assertEquals("1.21.11-R0.1-SNAPSHOT", Version.fromString("1.21.11-R0.1-SNAPSHOT").toString());
+        assertEquals("26.1-R0.1-SNAPSHOT", Version.fromString("26.1-R0.1-SNAPSHOT").toString());
+        assertEquals("26.1.1-R0.1-SNAPSHOT", Version.fromString("26.1.1-R0.1-SNAPSHOT").toString());
     }
 
     @Test

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
-org.gradle.configuration-cache=true
-org.gradle.configuration-cache.parallel=true
-org.gradle.caching=true
-org.gradle.parallel=true
-org.gradle.daemon=true
+# org.gradle.configuration-cache=true
+# org.gradle.configuration-cache.parallel=true
+# org.gradle.caching=true
+# org.gradle.parallel=true
+# org.gradle.daemon=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,5 @@
+org.gradle.configuration-cache=true
+org.gradle.configuration-cache.parallel=true
+org.gradle.caching=true
+org.gradle.parallel=true
+org.gradle.daemon=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,0 @@
-# org.gradle.configuration-cache=true
-# org.gradle.configuration-cache.parallel=true
-# org.gradle.caching=true
-# org.gradle.parallel=true
-# org.gradle.daemon=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -8,8 +8,8 @@ pluginManagement {
 
     plugins {
         id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
-        id("com.gradleup.shadow") version "9.2.2"
-        id("xyz.wagyourtail.jvmdowngrader") version "1.3.4"
+        id("com.gradleup.shadow") version "9.4.1"
+        id("xyz.wagyourtail.jvmdowngrader") version "1.3.6"
     }
 }
 


### PR DESCRIPTION
This pull request adds support for the latest Paper Minecraft server versions (26.1 and 26.1.1), updates dependencies and build tooling, and improves version handling throughout the project. The changes ensure compatibility with new server releases and keep the build and CI infrastructure up to date.

**Support for new Minecraft/Paper versions:**

- Added new version constants `V26_1` and `V26_1_1` to the `Version` class, and extended the version-specific handler system to support these versions by adding new handler classes (`VersionSpecificHandler_V26_1.java` and `VersionSpecificHandler_V26_1_1.java`). Registered these handlers in `VersionSpecificHandler`. [[1]](diffhunk://#diff-1c0e3ffdf1e1e989006bcd808c23a3c516587ca41d4ea1ba72d42f2caecec930R27-R28) [[2]](diffhunk://#diff-9d75e266c1d1ddfd9445fe85f5f20fa90e7a74606e717f9faca587d659f5fba5R1-R13) [[3]](diffhunk://#diff-3f81d71030bcf6b9b34fc7cada1613274f31361dc1ca8e4abb755c8de4fec25bR1-R13) [[4]](diffhunk://#diff-c1fba6b42a98c90e7c333c529d9b5a5652fe353f74b5d9d102675434cfca2609R73-R74)
- Updated the Paper API dependency in `bukkit/build.gradle.kts` to `io.papermc.paper:paper-api:26.1.1.build.+` for compatibility with the latest server versions.
   - Server logs for the latest *at the time of writing* Alpha version of Paper 26.1.1 available: https://mclo.gs/qeZVDzg

**Build and CI improvements:**

- Updated GitHub Actions workflow files to use the latest versions of actions, switched build and publish runners to `ubuntu-latest`, and added support for Java 25 and Java 21 downgraded plugin JARs. [[1]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R2-R74) [[2]](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7R2-R23)
- Upgraded Gradle wrapper to 9.4.1 and bumped plugin versions in `settings.gradle.kts` for `shadow` and `jvmdowngrader`. [[1]](diffhunk://#diff-40640fe1078ece83d7ea8fb67daacd77923a86d13447baf9769660b3b46f2eceL3-R3) [[2]](diffhunk://#diff-5625e3601fa0ad3a6a2824239e5a2fde71c149597d31394f9224a08c24be7b9dL11-R12)

**Version parsing and test improvements:**

- Improved version string parsing in `Version.fromString` to correctly handle `.build` suffixes, ensuring accurate version detection for new Paper versions. Added tests for parsing new version formats. [[1]](diffhunk://#diff-1c0e3ffdf1e1e989006bcd808c23a3c516587ca41d4ea1ba72d42f2caecec930L167-R172) [[2]](diffhunk://#diff-359b34a53f5aa62241b4078ffff0bb3edc2c5b19a8b8748d817e4ee5fa6430bcR100-R101)

**Build script maintenance:**

- Minor cleanup in `bukkit/build.gradle.kts` for repository declarations.