### PR TITLE
Upgrade Gradle, deps, and add support for Minecraft 26.1.x

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,55 +1,55 @@
 name: Build plugin
-on: [pull_request, push]
+on: [ pull_request, push ]
 jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-latest]
-        distribution: [temurin]
-        java-version: ["21"]
+        os: [ ubuntu-latest ]
+        distribution: [ temurin ]
+        java-version: [ "21" ]
     runs-on: ${{ matrix.os }}
     if: "!startsWith(github.event.head_commit.message, '[ci-skip]')"
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-      - name: "Setup JDK (${{ matrix.distribution }} ${{ matrix.java-version }})"
-        uses: actions/setup-java@v4
-        with:
-          distribution: "${{ matrix.distribution }}"
-          java-version: "${{ matrix.java-version }}"
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
-      - name: Execute Gradle build
-        run: ./gradlew --no-daemon --stacktrace
-      - name: "Upload the Java ${{ matrix.java-version }} plugin JAR"
-        uses: actions/upload-artifact@v4
-        with:
-          name: "! Quests-JDK${{ matrix.java-version }}"
-          path: |
-            build/libs/*.jar
-            !build/libs/*-downgraded-*.jar
-          if-no-files-found: error
-      - name: Upload the downgraded Java 8 plugin JAR
-        uses: actions/upload-artifact@v4
-        with:
-          name: Quests-JDK1.8 (use at your own risk)
-          path: build/libs/*-downgraded-8-shaded.jar
-          if-no-files-found: error
-      - name: Upload the downgraded Java 11 plugin JAR
-        uses: actions/upload-artifact@v4
-        with:
-          name: Quests-JDK11 (use at your own risk)
-          path: build/libs/*-downgraded-11-shaded.jar
-          if-no-files-found: error
-      - name: Upload the downgraded Java 16 plugin JAR
-        uses: actions/upload-artifact@v4
-        with:
-          name: Quests-JDK16 (use at your own risk)
-          path: build/libs/*-downgraded-16-shaded.jar
-          if-no-files-found: error
-      - name: Upload the downgraded Java 17 plugin JAR
-        uses: actions/upload-artifact@v4
-        with:
-          name: Quests-JDK17 (use at your own risk)
-          path: build/libs/*-downgraded-17-shaded.jar
-          if-no-files-found: error
+    - name: Checkout repository
+      uses: actions/checkout@v6
+    - name: "Setup JDK (${{ matrix.distribution }} ${{ matrix.java-version }})"
+      uses: actions/setup-java@v5
+      with:
+        distribution: "${{ matrix.distribution }}"
+        java-version: "${{ matrix.java-version }}"
+    - name: Setup Gradle
+      uses: gradle/actions/setup-gradle@v6
+    - name: Execute Gradle build
+      run: ./gradlew --no-daemon --stacktrace
+    - name: "Upload the Java ${{ matrix.java-version }} plugin JAR"
+      uses: actions/upload-artifact@v7
+      with:
+        name: "! Quests-JDK${{ matrix.java-version }}"
+        path: |
+          build/libs/*.jar
+          !build/libs/*-downgraded-*.jar
+        if-no-files-found: error
+    - name: Upload the downgraded Java 8 plugin JAR
+      uses: actions/upload-artifact@v7
+      with:
+        name: Quests-JDK1.8 (use at your own risk)
+        path: build/libs/*-downgraded-8-shaded.jar
+        if-no-files-found: error
+    - name: Upload the downgraded Java 11 plugin JAR
+      uses: actions/upload-artifact@v7
+      with:
+        name: Quests-JDK11 (use at your own risk)
+        path: build/libs/*-downgraded-11-shaded.jar
+        if-no-files-found: error
+    - name: Upload the downgraded Java 16 plugin JAR
+      uses: actions/upload-artifact@v7
+      with:
+        name: Quests-JDK16 (use at your own risk)
+        path: build/libs/*-downgraded-16-shaded.jar
+        if-no-files-found: error
+    - name: Upload the downgraded Java 17 plugin JAR
+      uses: actions/upload-artifact@v7
+      with:
+        name: Quests-JDK17 (use at your own risk)
+        path: build/libs/*-downgraded-17-shaded.jar
+        if-no-files-found: error

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,26 +1,34 @@
 name: Build plugin
+
 on: [ pull_request, push ]
+
 jobs:
   build:
     strategy:
       matrix:
         os: [ ubuntu-latest ]
         distribution: [ temurin ]
-        java-version: [ "21" ]
+        java-version: [ "25" ]
+
     runs-on: ${{ matrix.os }}
     if: "!startsWith(github.event.head_commit.message, '[ci-skip]')"
+
     steps:
     - name: Checkout repository
       uses: actions/checkout@v6
+
     - name: "Setup JDK (${{ matrix.distribution }} ${{ matrix.java-version }})"
       uses: actions/setup-java@v5
       with:
         distribution: "${{ matrix.distribution }}"
         java-version: "${{ matrix.java-version }}"
+
     - name: Setup Gradle
       uses: gradle/actions/setup-gradle@v6
+
     - name: Execute Gradle build
       run: ./gradlew --no-daemon --stacktrace
+
     - name: "Upload the Java ${{ matrix.java-version }} plugin JAR"
       uses: actions/upload-artifact@v7
       with:
@@ -29,27 +37,38 @@ jobs:
           build/libs/*.jar
           !build/libs/*-downgraded-*.jar
         if-no-files-found: error
+
     - name: Upload the downgraded Java 8 plugin JAR
       uses: actions/upload-artifact@v7
       with:
         name: Quests-JDK1.8 (use at your own risk)
         path: build/libs/*-downgraded-8-shaded.jar
         if-no-files-found: error
+
     - name: Upload the downgraded Java 11 plugin JAR
       uses: actions/upload-artifact@v7
       with:
         name: Quests-JDK11 (use at your own risk)
         path: build/libs/*-downgraded-11-shaded.jar
         if-no-files-found: error
+
     - name: Upload the downgraded Java 16 plugin JAR
       uses: actions/upload-artifact@v7
       with:
         name: Quests-JDK16 (use at your own risk)
         path: build/libs/*-downgraded-16-shaded.jar
         if-no-files-found: error
+
     - name: Upload the downgraded Java 17 plugin JAR
       uses: actions/upload-artifact@v7
       with:
         name: Quests-JDK17 (use at your own risk)
         path: build/libs/*-downgraded-17-shaded.jar
+        if-no-files-found: error
+
+    - name: Upload the downgraded Java 21 plugin JAR
+      uses: actions/upload-artifact@v7
+      with:
+        name: Quests-JDK21 (use at your own risk)
+        path: build/libs/*-downgraded-21-shaded.jar
         if-no-files-found: error

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,61 +14,61 @@ jobs:
     if: "!startsWith(github.event.head_commit.message, '[ci-skip]')"
 
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v6
+      - name: Checkout repository
+        uses: actions/checkout@v6
 
-    - name: "Setup JDK (${{ matrix.distribution }} ${{ matrix.java-version }})"
-      uses: actions/setup-java@v5
-      with:
-        distribution: "${{ matrix.distribution }}"
-        java-version: "${{ matrix.java-version }}"
+      - name: "Setup JDK (${{ matrix.distribution }} ${{ matrix.java-version }})"
+        uses: actions/setup-java@v5
+        with:
+          distribution: "${{ matrix.distribution }}"
+          java-version: "${{ matrix.java-version }}"
 
-    - name: Setup Gradle
-      uses: gradle/actions/setup-gradle@v6
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v6
 
-    - name: Execute Gradle build
-      run: ./gradlew --no-daemon --stacktrace
+      - name: Execute Gradle build
+        run: ./gradlew --no-daemon --stacktrace
 
-    - name: "Upload the Java ${{ matrix.java-version }} plugin JAR"
-      uses: actions/upload-artifact@v7
-      with:
-        name: "! Quests-JDK${{ matrix.java-version }}"
-        path: |
-          build/libs/*.jar
-          !build/libs/*-downgraded-*.jar
-        if-no-files-found: error
+      - name: "Upload the Java ${{ matrix.java-version }} plugin JAR"
+        uses: actions/upload-artifact@v7
+        with:
+          name: "! Quests-JDK${{ matrix.java-version }}"
+          path: |
+            build/libs/*.jar
+            !build/libs/*-downgraded-*.jar
+          if-no-files-found: error
 
-    - name: Upload the downgraded Java 8 plugin JAR
-      uses: actions/upload-artifact@v7
-      with:
-        name: Quests-JDK1.8 (use at your own risk)
-        path: build/libs/*-downgraded-8-shaded.jar
-        if-no-files-found: error
+      - name: Upload the downgraded Java 8 plugin JAR
+        uses: actions/upload-artifact@v7
+        with:
+          name: Quests-JDK1.8 (use at your own risk)
+          path: build/libs/*-downgraded-8-shaded.jar
+          if-no-files-found: error
 
-    - name: Upload the downgraded Java 11 plugin JAR
-      uses: actions/upload-artifact@v7
-      with:
-        name: Quests-JDK11 (use at your own risk)
-        path: build/libs/*-downgraded-11-shaded.jar
-        if-no-files-found: error
+      - name: Upload the downgraded Java 11 plugin JAR
+        uses: actions/upload-artifact@v7
+        with:
+          name: Quests-JDK11 (use at your own risk)
+          path: build/libs/*-downgraded-11-shaded.jar
+          if-no-files-found: error
 
-    - name: Upload the downgraded Java 16 plugin JAR
-      uses: actions/upload-artifact@v7
-      with:
-        name: Quests-JDK16 (use at your own risk)
-        path: build/libs/*-downgraded-16-shaded.jar
-        if-no-files-found: error
+      - name: Upload the downgraded Java 16 plugin JAR
+        uses: actions/upload-artifact@v7
+        with:
+          name: Quests-JDK16 (use at your own risk)
+          path: build/libs/*-downgraded-16-shaded.jar
+          if-no-files-found: error
 
-    - name: Upload the downgraded Java 17 plugin JAR
-      uses: actions/upload-artifact@v7
-      with:
-        name: Quests-JDK17 (use at your own risk)
-        path: build/libs/*-downgraded-17-shaded.jar
-        if-no-files-found: error
+      - name: Upload the downgraded Java 17 plugin JAR
+        uses: actions/upload-artifact@v7
+        with:
+          name: Quests-JDK17 (use at your own risk)
+          path: build/libs/*-downgraded-17-shaded.jar
+          if-no-files-found: error
 
-    - name: Upload the downgraded Java 21 plugin JAR
-      uses: actions/upload-artifact@v7
-      with:
-        name: Quests-JDK21 (use at your own risk)
-        path: build/libs/*-downgraded-21-shaded.jar
-        if-no-files-found: error
+      - name: Upload the downgraded Java 21 plugin JAR
+        uses: actions/upload-artifact@v7
+        with:
+          name: Quests-JDK21 (use at your own risk)
+          path: build/libs/*-downgraded-21-shaded.jar
+          if-no-files-found: error

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,7 +27,7 @@ jobs:
         working-directory: docs
     steps:
     - name: Checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@v4
     - name: Setup Ruby
       uses: ruby/setup-ruby@v1
       with:
@@ -37,7 +37,7 @@ jobs:
         working-directory: '${{ github.workspace }}/docs'
     - name: Setup Pages
       id: pages
-      uses: actions/configure-pages@v6
+      uses: actions/configure-pages@v4
     - name: Build with Jekyll
       # Outputs to the './_site' directory by default
       run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
@@ -45,7 +45,7 @@ jobs:
         JEKYLL_ENV: production
     - name: Upload artifact
       # Automatically uploads an artifact from the './_site' directory by default
-      uses: actions/upload-pages-artifact@v4
+      uses: actions/upload-pages-artifact@v3
       with:
         path: "docs/_site/"
 
@@ -59,4 +59,4 @@ jobs:
     steps:
     - name: Deploy to GitHub Pages
       id: deployment
-      uses: actions/deploy-pages@v5
+      uses: actions/deploy-pages@v4

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,12 +2,12 @@ name: Build documentation
 on:
   push:
     branches:
-      - "master"
+    - "master"
     paths:
-      - "docs/**"
+    - "docs/**"
   workflow_dispatch:
 
-# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+    # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
   contents: read
   pages: write
@@ -26,28 +26,28 @@ jobs:
       run:
         working-directory: docs
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Setup Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: '3.4.1' # Not needed with a .ruby-version file
-          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
-          cache-version: 0 # Increment this number if you need to re-download cached gems
-          working-directory: '${{ github.workspace }}/docs'
-      - name: Setup Pages
-        id: pages
-        uses: actions/configure-pages@v4
-      - name: Build with Jekyll
-        # Outputs to the './_site' directory by default
-        run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
-        env:
-          JEKYLL_ENV: production
-      - name: Upload artifact
-        # Automatically uploads an artifact from the './_site' directory by default
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: "docs/_site/"
+    - name: Checkout
+      uses: actions/checkout@v6
+    - name: Setup Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: '3.4.1' # Not needed with a .ruby-version file
+        bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+        cache-version: 0 # Increment this number if you need to re-download cached gems
+        working-directory: '${{ github.workspace }}/docs'
+    - name: Setup Pages
+      id: pages
+      uses: actions/configure-pages@v6
+    - name: Build with Jekyll
+      # Outputs to the './_site' directory by default
+      run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
+      env:
+        JEKYLL_ENV: production
+    - name: Upload artifact
+      # Automatically uploads an artifact from the './_site' directory by default
+      uses: actions/upload-pages-artifact@v4
+      with:
+        path: "docs/_site/"
 
   # Deployment job
   deploy:
@@ -57,6 +57,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+    - name: Deploy to GitHub Pages
+      id: deployment
+      uses: actions/deploy-pages@v5

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,21 +1,26 @@
 name: Publish plugin to repository
+
 on:
   push:
     tags:
     - '*'
+
 jobs:
   publish:
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
+
     steps:
     - uses: actions/checkout@v6
+
     - name: Set up Java
       uses: actions/setup-java@v5
       with:
         java-version: '8.0'
         distribution: 'adopt'
+
     - name: Publish to repository
       run: gradle publish
       env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Set up Java
       uses: actions/setup-java@v5
       with:
-        java-version: '17'
+        java-version: '25'
         distribution: 'temurin'
 
     - name: Publish to repository

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,22 +2,22 @@ name: Publish plugin to repository
 on:
   push:
     tags:
-      - '*'
+    - '*'
 jobs:
   publish:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v2
-      - name: Set up Java
-        uses: actions/setup-java@v2
-        with:
-          java-version: '8.0'
-          distribution: 'adopt'
-      - name: Publish to repository
-        run: gradle publish
-        env:
-          MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
-          MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
+    - uses: actions/checkout@v6
+    - name: Set up Java
+      uses: actions/setup-java@v5
+      with:
+        java-version: '8.0'
+        distribution: 'adopt'
+    - name: Publish to repository
+      run: gradle publish
+      env:
+        MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
+        MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,7 +3,7 @@ name: Publish plugin to repository
 on:
   push:
     tags:
-    - '*'
+      - '*'
 
 jobs:
   publish:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,8 +18,8 @@ jobs:
     - name: Set up Java
       uses: actions/setup-java@v5
       with:
-        java-version: '8.0'
-        distribution: 'adopt'
+        java-version: '17'
+        distribution: 'temurin'
 
     - name: Publish to repository
       run: gradle publish

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,7 +3,7 @@ name: Publish plugin to repository
 on:
   push:
     tags:
-      - '*'
+    - '*'
 
 jobs:
   publish:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,7 @@ jobs:
         distribution: 'temurin'
 
     - name: Publish to repository
-      run: gradle publish
+      run: ./gradlew publish
       env:
         MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
         MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ UPDATE_MESSAGE
 *.project
 */bin/
 *.settings/
+
+# VS Code
+.vscode/

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,7 +15,7 @@ allprojects {
 
     java {
         toolchain {
-            languageVersion = JavaLanguageVersion.of(21)
+            languageVersion = JavaLanguageVersion.of(25)
         }
     }
 }
@@ -24,7 +24,7 @@ subprojects {
     tasks.withType<JavaCompile> {
         options.compilerArgs = listOf("-Xlint:deprecation", "-Xlint:unchecked")
         options.encoding = Charsets.UTF_8.name()
-        options.release = 21
+        options.release = 25
     }
 
     tasks.withType<Javadoc> {
@@ -89,7 +89,10 @@ val javaVersions = listOf(
     JavaVersion.VERSION_16,
 
     // from 1.18 to 1.20.4
-    JavaVersion.VERSION_17
+    JavaVersion.VERSION_17,
+
+    // from 1.20.4 to 1.21.11
+    JavaVersion.VERSION_21
 )
 
 for (javaVersion in javaVersions) {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,7 +11,7 @@ allprojects {
     apply(plugin = "java")
 
     group = "com.leonardobishop"
-    version = "3.16.1"
+    version = "3.16.2"
 
     java {
         toolchain {
@@ -91,7 +91,7 @@ val javaVersions = listOf(
     // from 1.18 to 1.20.4
     JavaVersion.VERSION_17,
 
-    // from 1.20.4 to 1.21.11
+    // from 1.20.5 to 1.21.11
     JavaVersion.VERSION_21
 )
 

--- a/bukkit/build.gradle.kts
+++ b/bukkit/build.gradle.kts
@@ -159,7 +159,7 @@ dependencies {
     // hppc
     implementation("com.carrotsearch:hppc:0.10.0")
     // bungeecord-chat
-    implementation("net.md-5:bungeecord-chat:26.1-R0.1-SNAPSHOT") { isTransitive = false }
+    implementation("net.md-5:bungeecord-chat:1.21-R0.4") { isTransitive = false }
 }
 
 tasks.shadowJar {

--- a/bukkit/build.gradle.kts
+++ b/bukkit/build.gradle.kts
@@ -74,7 +74,7 @@ dependencies {
     compileOnlyProject(":common")
 
     // Paper
-    compileOnly("io.papermc.paper:paper-api:26.1.1.build.+")
+    compileOnlyServer("io.papermc.paper:paper-api:26.1.1.build.+")
 
     // ASkyBlock
     compileOnlyPlugin("com.wasteofplastic:askyblock:3.0.9.4")
@@ -159,7 +159,7 @@ dependencies {
     // hppc
     implementation("com.carrotsearch:hppc:0.10.0")
     // bungeecord-chat
-    implementation("net.md-5:bungeecord-chat:1.21-R0.4") { isTransitive = false }
+    implementation("net.md-5:bungeecord-chat:26.1-R0.1-SNAPSHOT") { isTransitive = false }
 }
 
 tasks.shadowJar {

--- a/bukkit/build.gradle.kts
+++ b/bukkit/build.gradle.kts
@@ -16,7 +16,10 @@ tasks.withType<ProcessResources> {
 
 repositories {
     // Paper
-    maven("https://repo.papermc.io/repository/maven-public/")
+    maven {
+        name = "papermc"
+        url = uri("https://repo.papermc.io/repository/maven-public/")
+    }
     // Paper (adventure-bom snapshots)
     maven("https://s01.oss.sonatype.org/content/repositories/snapshots/")
     // ASkyBlock, BedWars1058, BentoBox, bStats, Citizens
@@ -71,7 +74,7 @@ dependencies {
     compileOnlyProject(":common")
 
     // Paper
-    compileOnlyServer("io.papermc.paper:paper-api:1.21.11-pre3-R0.1-SNAPSHOT")
+    compileOnly("io.papermc.paper:paper-api:26.1.1.build.+")
 
     // ASkyBlock
     compileOnlyPlugin("com.wasteofplastic:askyblock:3.0.9.4")

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/hook/versionspecific/VersionSpecificHandler.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/hook/versionspecific/VersionSpecificHandler.java
@@ -70,6 +70,8 @@ public interface VersionSpecificHandler {
         this.add(Version.V1_21_2);
         this.add(Version.V1_21_6);
         this.add(Version.V1_21_11);
+        this.add(Version.V26_1);
+        this.add(Version.V26_1_1);
     }});
 
     static VersionSpecificHandler getImplementation(final Version serverVersion) {

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/hook/versionspecific/VersionSpecificHandler_V26_1.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/hook/versionspecific/VersionSpecificHandler_V26_1.java
@@ -4,6 +4,7 @@ import com.leonardobishop.quests.common.versioning.Version;
 import org.jspecify.annotations.NullMarked;
 
 @NullMarked
+@SuppressWarnings("PMD.ClassNamingConventions")
 public class VersionSpecificHandler_V26_1 extends VersionSpecificHandler_V1_21_11 {
 
     @Override

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/hook/versionspecific/VersionSpecificHandler_V26_1.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/hook/versionspecific/VersionSpecificHandler_V26_1.java
@@ -1,0 +1,13 @@
+package com.leonardobishop.quests.bukkit.hook.versionspecific;
+
+import com.leonardobishop.quests.common.versioning.Version;
+import org.jspecify.annotations.NullMarked;
+
+@NullMarked
+public class VersionSpecificHandler_V26_1 extends VersionSpecificHandler_V1_21_11 {
+
+    @Override
+    public Version getMinecraftVersion() {
+        return Version.V26_1;
+    }
+}

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/hook/versionspecific/VersionSpecificHandler_V26_1_1.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/hook/versionspecific/VersionSpecificHandler_V26_1_1.java
@@ -1,0 +1,13 @@
+package com.leonardobishop.quests.bukkit.hook.versionspecific;
+
+import com.leonardobishop.quests.common.versioning.Version;
+import org.jspecify.annotations.NullMarked;
+
+@NullMarked
+public class VersionSpecificHandler_V26_1_1 extends VersionSpecificHandler_V26_1 {
+
+    @Override
+    public Version getMinecraftVersion() {
+        return Version.V26_1_1;
+    }
+}

--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/hook/versionspecific/VersionSpecificHandler_V26_1_1.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/hook/versionspecific/VersionSpecificHandler_V26_1_1.java
@@ -4,6 +4,7 @@ import com.leonardobishop.quests.common.versioning.Version;
 import org.jspecify.annotations.NullMarked;
 
 @NullMarked
+@SuppressWarnings("PMD.ClassNamingConventions")
 public class VersionSpecificHandler_V26_1_1 extends VersionSpecificHandler_V26_1 {
 
     @Override

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -11,10 +11,10 @@ dependencies {
     api("org.jspecify:jspecify:1.0.0")
 
     // Use it for contracts and unmodifiability annotations
-    api("org.jetbrains:annotations:26.0.2")
+    api("org.jetbrains:annotations:26.1.0")
 
     // Testing dependencies
-    testImplementation("org.junit.jupiter:junit-jupiter:6.0.2")
+    testImplementation("org.junit.jupiter:junit-jupiter:6.0.3")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }
 

--- a/common/src/main/java/com/leonardobishop/quests/common/versioning/Version.java
+++ b/common/src/main/java/com/leonardobishop/quests/common/versioning/Version.java
@@ -24,6 +24,8 @@ public final class Version implements Comparable<Version> {
     public static final Version V1_21_2 = new Version(1, 21, 2);
     public static final Version V1_21_6 = new Version(1, 21, 6);
     public static final Version V1_21_11 = new Version(1, 21, 11);
+    public static final Version V26_1 = new Version(26, 1);
+    public static final Version V26_1_1 = new Version(26, 1, 1);
     public static final Version UNKNOWN = new Version(Integer.MAX_VALUE);
 
     private final @Nullable String preRelease;

--- a/common/src/main/java/com/leonardobishop/quests/common/versioning/Version.java
+++ b/common/src/main/java/com/leonardobishop/quests/common/versioning/Version.java
@@ -165,7 +165,6 @@ public final class Version implements Comparable<Version> {
                 ? str.substring(plusIndex + 1)
                 : null;
 
-        final int optionalIndex = minusIndex != -1 ? minusIndex : plusIndex;
         String versionCore = optionalIndex != -1 ? str.substring(0, optionalIndex) : str;
         if (versionCore.contains(".build")) {
             versionCore = versionCore.substring(0, versionCore.indexOf(".build"));

--- a/common/src/main/java/com/leonardobishop/quests/common/versioning/Version.java
+++ b/common/src/main/java/com/leonardobishop/quests/common/versioning/Version.java
@@ -165,7 +165,7 @@ public final class Version implements Comparable<Version> {
                 ? str.substring(plusIndex + 1)
                 : null;
 
-        String versionCore = optionalIndex != -1 ? str.substring(0, optionalIndex) : str;
+        String versionCore = minusIndex != -1 ? str.substring(0, minusIndex) : str;
         if (versionCore.contains(".build")) {
             versionCore = versionCore.substring(0, versionCore.indexOf(".build"));
         }

--- a/common/src/main/java/com/leonardobishop/quests/common/versioning/Version.java
+++ b/common/src/main/java/com/leonardobishop/quests/common/versioning/Version.java
@@ -166,7 +166,10 @@ public final class Version implements Comparable<Version> {
                 : null;
 
         final int optionalIndex = minusIndex != -1 ? minusIndex : plusIndex;
-        final String versionCore = optionalIndex != -1 ? str.substring(0, optionalIndex) : str;
+        String versionCore = optionalIndex != -1 ? str.substring(0, optionalIndex) : str;
+        if (versionCore.contains(".build")) {
+            versionCore = versionCore.substring(0, versionCore.indexOf(".build"));
+        }
         final String[] stringVersionParts = versionCore.split("\\.");
         final int[] versionParts = new int[stringVersionParts.length];
 

--- a/common/src/test/java/com/leonardobishop/quests/common/VersionTest.java
+++ b/common/src/test/java/com/leonardobishop/quests/common/VersionTest.java
@@ -97,6 +97,8 @@ public final class VersionTest {
         assertEquals("1.21.11-rc2-R0.1-SNAPSHOT", Version.fromString("1.21.11-rc2-R0.1-SNAPSHOT").toString());
         assertEquals("1.21.11-rc3-R0.1-SNAPSHOT", Version.fromString("1.21.11-rc3-R0.1-SNAPSHOT").toString());
         assertEquals("1.21.11-R0.1-SNAPSHOT", Version.fromString("1.21.11-R0.1-SNAPSHOT").toString());
+        assertEquals("26.1-R0.1-SNAPSHOT", Version.fromString("26.1-R0.1-SNAPSHOT").toString());
+        assertEquals("26.1.1-R0.1-SNAPSHOT", Version.fromString("26.1.1-R0.1-SNAPSHOT").toString());
     }
 
     @Test

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
-org.gradle.configuration-cache=true
-org.gradle.configuration-cache.parallel=true
-org.gradle.caching=true
-org.gradle.parallel=true
-org.gradle.daemon=true
+# org.gradle.configuration-cache=true
+# org.gradle.configuration-cache.parallel=true
+# org.gradle.caching=true
+# org.gradle.parallel=true
+# org.gradle.daemon=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,5 @@
+org.gradle.configuration-cache=true
+org.gradle.configuration-cache.parallel=true
+org.gradle.caching=true
+org.gradle.parallel=true
+org.gradle.daemon=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,0 @@
-# org.gradle.configuration-cache=true
-# org.gradle.configuration-cache.parallel=true
-# org.gradle.caching=true
-# org.gradle.parallel=true
-# org.gradle.daemon=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -8,8 +8,8 @@ pluginManagement {
 
     plugins {
         id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
-        id("com.gradleup.shadow") version "9.2.2"
-        id("xyz.wagyourtail.jvmdowngrader") version "1.3.4"
+        id("com.gradleup.shadow") version "9.4.1"
+        id("xyz.wagyourtail.jvmdowngrader") version "1.3.6"
     }
 }
 


### PR DESCRIPTION
# Minecraft/Paper 26.1/26.1.1 Support:

* Added support for Minecraft/Paper versions 26.1 and 26.1.1, including new constants in the `Version` class, new version-specific handler classes, and registration in the handler factory.
* Updated the Paper API and BungeeCord-Chat dependencies to versions compatible with 26.1.x in `bukkit/build.gradle.kts`. 
* Added tests for parsing new version strings in `VersionTest.java`.

----

# Build and Dependency Upgrades:

* Upgraded Gradle wrapper to 9.4.1 and updated plugin versions in `settings.gradle.kts` for `shadow` and `jvmdowngrader`.
* Updated various dependency versions, including `org.jetbrains:annotations` and `junit-jupiter` in `common/build.gradle.kts`.

----

# CI Workflow Improvements:

* Updated GitHub Actions workflows to use the latest action versions, Java 25 for builds, and added build matrix and artifact upload for new Java versions (including Java 21).