### PR TITLE
Added hasCompletedQuest to QPlayer and QuestController

### DIFF
--- a/bukkit/src/main/java/com/leonardobishop/quests/bukkit/questcontroller/NormalQuestController.java
+++ b/bukkit/src/main/java/com/leonardobishop/quests/bukkit/questcontroller/NormalQuestController.java
@@ -291,6 +291,12 @@ public class NormalQuestController implements QuestController {
                 : qPlayer.getQuestProgressFile().hasQuestStarted(quest);
     }
 
+    @Override
+    public boolean hasPlayerCompletedQuest(QPlayer qPlayer, Quest quest) {
+        QuestProgress questProgress = qPlayer.getQuestProgressFile().getQuestProgressOrNull(quest);
+        return questProgress != null && questProgress.isCompleted();
+    }
+
     private void resetQuest(QuestProgress questProgress) {
         questProgress.setStarted(false);
         questProgress.setStartedDate(System.currentTimeMillis());

--- a/common/src/main/java/com/leonardobishop/quests/common/player/QPlayer.java
+++ b/common/src/main/java/com/leonardobishop/quests/common/player/QPlayer.java
@@ -114,6 +114,21 @@ public final class QPlayer {
     }
 
     /**
+     * Gets whether the player has completed a specific quest.
+     * 
+     * For repeatable quests, this returns true if the player has completed the current quest cycle.
+     *
+     * @param quest the quest to test for
+     * @return true if the quest is completed, false otherwise
+     */
+    @Contract(pure = true)
+    public boolean hasCompletedQuest(final Quest quest) {
+        Objects.requireNonNull(quest, "quest cannot be null");
+
+        return this.questController.hasPlayerCompletedQuest(this, quest);
+    }
+    
+    /**
      * Attempt to complete a quest for the player. This will also play all effects (such as titles, messages etc.)
      * and also dispatches all rewards for the player.
      *

--- a/common/src/main/java/com/leonardobishop/quests/common/questcontroller/QuestController.java
+++ b/common/src/main/java/com/leonardobishop/quests/common/questcontroller/QuestController.java
@@ -25,6 +25,9 @@ public interface QuestController {
     @Contract(pure = true)
     boolean hasPlayerStartedQuest(QPlayer qPlayer, Quest quest);
 
+    @Contract(pure = true)
+    boolean hasPlayerCompletedQuest(QPlayer qPlayer, Quest quest);
+
     QuestStartResult startQuestForPlayer(QPlayer qPlayer, Quest quest);
 
     boolean completeQuestForPlayer(QPlayer qPlayer, Quest quest);


### PR DESCRIPTION
Added `hasCompletedQuest(Quest)` to `QPlayer` for consistency with existing API methods.

Currently, checking quest completion requires going through `QPlayer -> QPlayerData -> QuestProgressFile`, which is functional but less ergonomic.

This change adds a consistent API surface alongside `hasStartedQuest`, `startQuest`, and `completeQuest`

Implementation delegates to the existing `QuestProgressFile` logic, so no duplication of state or logic is introduced.

Tested on Paper 1.21.11 using the downgraded Java 21 file